### PR TITLE
Merge dev into master: improve FrontPanel diagnostics, device discovery, and bitstream path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,31 @@ The package first looks for its packaged BIST bitstreams. For backward compatibi
 
 ## Bitstream paths
 
-`XEM7310(bitstream_path)` and `XEM7360(bitstream_path)` accept absolute paths
-and relative paths. Relative paths are resolved from `../bitstreams` relative to
-the current working directory of the Python process. The package does not search
-for a project root.
+`XEM7310(bitstream_path)` and `XEM7360(bitstream_path)` accept absolute paths,
+such as `C:\path\to\design.bit`. `~` and environment variables are expanded.
+When only a bitstream filename such as `design.bit` is provided, it is loaded
+from `../bitstreams` relative to the current working directory.
+
+Examples:
+
+```python
+from mms_ok import XEM7310
+
+# Absolute path: uses this exact file after path expansion.
+fpga = XEM7310(r"C:\Users\JY\fpga\design.bit")
+
+# User-home path: "~" expands to the current user's home directory.
+fpga = XEM7310("~/fpga/design.bit")
+
+# Environment variable path: "%USERPROFILE%" expands before loading.
+fpga = XEM7310(r"%USERPROFILE%\fpga\design.bit")
+
+# Filename only: loads "../bitstreams/design.bit" from the current working directory.
+fpga = XEM7310("design.bit")
+```
 
 If a bitstream is missing, the error message includes the checked candidate
-path. BIST continues to use the packaged bitstreams under `mms_ok/bitstreams`
+paths. BIST continues to use the packaged bitstreams under `mms_ok/bitstreams`
 first, then the legacy `%USERPROFILE%\mms_ok\bitstreams` fallback.
 
 ## Typical lab workflow

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The package also includes BIST bitstreams under `mms_ok/bitstreams` for supporte
 - Pipe and block-pipe transfer helpers for strings, byte buffers, and NumPy arrays.
 - Register bridge read/write helpers.
 - LED helpers for supported XEM boards.
-- CLI commands for version checks, SDK checks, FrontPanel setup, and BIST.
+- Device discovery from Python and the CLI.
+- CLI commands for version checks, SDK checks, FrontPanel setup, device listing, and BIST.
 
 ## Requirements
 
@@ -78,6 +79,30 @@ mms_ok setup-frontpanel
 mms_ok check-sdk
 ```
 
+## Device discovery
+
+List attached FrontPanel devices from the CLI:
+
+```bash
+mms_ok devices
+python -m mms_ok devices
+```
+
+The command prints `device_id`, `model`, and `serial`.
+`device_id` is the Opal Kelly `okTDeviceInfo.deviceID` string.
+
+Use the same discovery from Python:
+
+```python
+import mms_ok
+
+for device in mms_ok.list_devices():
+    print(device.serial, device.model, device.device_id, device.product_id)
+```
+
+`mms_ok.list_devices()` imports the FrontPanel SDK lazily, so `import mms_ok`
+does not require the SDK to be installed.
+
 ## Built-in self-test (BIST)
 
 BIST is the quickest way to confirm that the installed package, FrontPanel SDK, connected board, and packaged board-test bitstream can work together.
@@ -96,16 +121,28 @@ python -m mms_ok bist
 
 The package first looks for its packaged BIST bitstreams. For backward compatibility, it can also fall back to `%USERPROFILE%\mms_ok\bitstreams` if packaged files are unavailable.
 
+## Bitstream paths
+
+`XEM7310(bitstream_path)` and `XEM7360(bitstream_path)` accept absolute paths
+and relative paths. Relative paths are resolved from `../bitstreams` relative to
+the current working directory of the Python process. The package does not search
+for a project root.
+
+If a bitstream is missing, the error message includes the checked candidate
+path. BIST continues to use the packaged bitstreams under `mms_ok/bitstreams`
+first, then the legacy `%USERPROFILE%\mms_ok\bitstreams` fallback.
+
 ## Typical lab workflow
 
 A typical session is:
 
 1. Install the Windows FrontPanel SDK with the setup guide above.
 2. Install `mms_ok` and verify that it can import the FrontPanel SDK with `mms_ok check-sdk`.
-3. Connect a supported XEM board and, when appropriate, verify it with `mms_ok bist`.
-4. Load your `.bit` file with `XEM7310` or `XEM7360`.
-5. Use wires, triggers, pipes, and registers to control and inspect your FPGA design.
-6. Close the device when finished. Prefer a context manager in scripts.
+3. Connect a supported XEM board and verify visibility with `mms_ok devices`.
+4. When appropriate, verify the board with `mms_ok bist`.
+5. Load your `.bit` file with `XEM7310` or `XEM7360`.
+6. Use wires, triggers, pipes, and registers to control and inspect your FPGA design.
+7. Close the device when finished. Prefer a context manager in scripts.
 
 ### Script-style usage with a context manager
 
@@ -252,11 +289,12 @@ FrontPanel endpoint ranges used by the helpers follow the standard Opal Kelly la
 Import the public classes from `mms_ok`:
 
 ```python
-from mms_ok import BIST, XEM7310, XEM7360
+from mms_ok import BIST, XEM7310, XEM7360, list_devices
 ```
 
 Common methods on `XEM7310` and `XEM7360` include:
 
+- Discovery: `list_devices()`.
 - Device lifecycle: `close()`, context manager support, `reset(...)`.
 - LEDs: `SetLED(...)`.
 - Wires: `SetWireInValue(...)`, `UpdateWireIns()`, `UpdateWireOuts()`, `GetWireOutValue(...)`.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ mms_ok --help
 mms_ok version
 ```
 
+Running `mms_ok` with no arguments opens an arrow-key setup helper menu for
+common FrontPanel and Jupyter environment diagnostics.
+
 Finally, verify that `mms_ok` can import the FrontPanel SDK as `ok`:
 
 ```bash

--- a/mms_ok/__init__.py
+++ b/mms_ok/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "XEM7360",
     "__version__",
     "copy_frontpanel_files",
+    "list_devices",
     "setup_frontpanel",
 ]
 
@@ -55,6 +56,10 @@ def __getattr__(name):
         return copy_frontpanel_files
     if name == "setup_frontpanel":
         return setup_frontpanel
+    if name == "list_devices":
+        from .devices import list_devices
+
+        return list_devices
     raise AttributeError("module {!r} has no attribute {!r}".format(__name__, name))
 
 

--- a/mms_ok/bist.py
+++ b/mms_ok/bist.py
@@ -17,6 +17,13 @@ from .address import (
     WIRE_IN_START,
     WIRE_OUT_START,
 )
+from .bitstreams import (
+    LEGACY_BITSTREAM_DIR,
+    PACKAGE_BITSTREAM_DIR,
+    bist_bitstream_candidates,
+    first_existing_path,
+    format_checked_paths,
+)
 from .bist_util import btpipe_progress, pipe_progress, trigger_progress, wire_progress
 from .diagnostics import log_critical, log_error
 from .fpga import XEM7310, XEM7360
@@ -24,10 +31,6 @@ from .fpga_config import FPGAConfig
 from .ok_setup import get_ok
 
 console = Console()
-
-PACKAGE_DIR = os.path.dirname(__file__)
-PACKAGE_BITSTREAM_DIR = os.path.join(PACKAGE_DIR, "bitstreams")
-LEGACY_BITSTREAM_DIR = os.path.expanduser("~/mms_ok/bitstreams")
 
 NUM_TEST_CHANNELS = 32
 PIPE_TRANSFER_BYTES = 128 // 8
@@ -80,19 +83,14 @@ class BIST:
 
     @staticmethod
     def _resolve_bitstream_path(bitstream_name: str) -> str:
-        candidate_paths = [
-            os.path.join(PACKAGE_BITSTREAM_DIR, bitstream_name),
-            os.path.join(LEGACY_BITSTREAM_DIR, bitstream_name),
-        ]
-
-        for path in candidate_paths:
-            if os.path.isfile(path):
-                logger.info(f"Using BIST bitstream: {path}")
-                return path
+        resolution = first_existing_path(bist_bitstream_candidates(bitstream_name))
+        if os.path.isfile(resolution.path):
+            logger.info(f"Using BIST bitstream: {resolution.path}")
+            return resolution.path
 
         raise FileNotFoundError(
             "BIST bitstream not found. Checked: {}".format(
-                ", ".join(candidate_paths)
+                format_checked_paths(resolution.checked_paths)
             )
         )
 

--- a/mms_ok/bitstreams.py
+++ b/mms_ok/bitstreams.py
@@ -30,8 +30,7 @@ def user_bitstream_candidates(bitstream_path: str) -> List[str]:
 
 
 def resolve_user_bitstream_path(bitstream_path: str) -> BitstreamResolution:
-    checked_paths = user_bitstream_candidates(bitstream_path)
-    return BitstreamResolution(path=checked_paths[0], checked_paths=checked_paths)
+    return first_existing_path(user_bitstream_candidates(bitstream_path))
 
 
 def bist_bitstream_candidates(bitstream_name: str) -> List[str]:

--- a/mms_ok/bitstreams.py
+++ b/mms_ok/bitstreams.py
@@ -1,0 +1,53 @@
+"""Bitstream path resolution helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable, List
+
+PACKAGE_DIR = os.path.dirname(__file__)
+PACKAGE_BITSTREAM_DIR = os.path.join(PACKAGE_DIR, "bitstreams")
+LEGACY_BITSTREAM_DIR = os.path.expanduser("~/mms_ok/bitstreams")
+USER_BITSTREAM_BASE_DIR = os.path.join("..", "bitstreams")
+
+
+@dataclass(frozen=True)
+class BitstreamResolution:
+    path: str
+    checked_paths: List[str]
+
+
+def _normalize(path: str) -> str:
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
+
+
+def user_bitstream_candidates(bitstream_path: str) -> List[str]:
+    expanded = os.path.expandvars(os.path.expanduser(bitstream_path))
+    if os.path.isabs(expanded):
+        return [_normalize(expanded)]
+    return [os.path.abspath(os.path.join(os.getcwd(), USER_BITSTREAM_BASE_DIR, expanded))]
+
+
+def resolve_user_bitstream_path(bitstream_path: str) -> BitstreamResolution:
+    checked_paths = user_bitstream_candidates(bitstream_path)
+    return BitstreamResolution(path=checked_paths[0], checked_paths=checked_paths)
+
+
+def bist_bitstream_candidates(bitstream_name: str) -> List[str]:
+    return [
+        os.path.join(PACKAGE_BITSTREAM_DIR, bitstream_name),
+        os.path.join(LEGACY_BITSTREAM_DIR, bitstream_name),
+    ]
+
+
+def first_existing_path(candidate_paths: Iterable[str]) -> BitstreamResolution:
+    checked_paths = [os.path.abspath(path) for path in candidate_paths]
+    for path in checked_paths:
+        if os.path.isfile(path):
+            return BitstreamResolution(path=path, checked_paths=checked_paths)
+    return BitstreamResolution(path=checked_paths[0], checked_paths=checked_paths)
+
+
+def format_checked_paths(paths: Iterable[str]) -> str:
+    return ", ".join(str(path) for path in paths)

--- a/mms_ok/bitstreams.py
+++ b/mms_ok/bitstreams.py
@@ -26,7 +26,11 @@ def user_bitstream_candidates(bitstream_path: str) -> List[str]:
     expanded = os.path.expandvars(os.path.expanduser(bitstream_path))
     if os.path.isabs(expanded):
         return [_normalize(expanded)]
-    return [os.path.abspath(os.path.join(os.getcwd(), USER_BITSTREAM_BASE_DIR, expanded))]
+    if os.path.basename(expanded) == expanded:
+        return [
+            os.path.abspath(os.path.join(os.getcwd(), USER_BITSTREAM_BASE_DIR, expanded))
+        ]
+    return [_normalize(expanded)]
 
 
 def resolve_user_bitstream_path(bitstream_path: str) -> BitstreamResolution:

--- a/mms_ok/cli.py
+++ b/mms_ok/cli.py
@@ -4,8 +4,14 @@ import argparse
 from typing import Optional, Sequence
 
 from rich.console import Console
+from rich.table import Table
 
 from . import __version__
+from .devices import (
+    DeviceDiscoveryError,
+    FrontPanelUnavailableError,
+    list_devices,
+)
 from .doctor import run_doctor
 from .ok_setup import (
     DEFAULT_FRONTPANEL_DIR,
@@ -23,6 +29,11 @@ LOCK_GUIDANCE = (
     "Close or restart Python processes, IPython/Jupyter kernels, notebooks, IDE "
     "terminals, or anything importing ok/_ok.pyd, then retry."
 )
+
+EXIT_SDK_UNAVAILABLE = 1
+EXIT_NO_DEVICES = 2
+EXIT_DISCOVERY_ERROR = 3
+
 
 def _run_bist(_args) -> int:
     from . import BIST
@@ -61,6 +72,38 @@ def _check_sdk(_args) -> int:
 
     print(f"FrontPanel SDK is available.")
     print(f"FrontPanel SDK version: {get_frontpanel_version(ok)}")
+    return 0
+
+
+def _list_devices(_args) -> int:
+    console = Console()
+
+    try:
+        devices = list_devices()
+    except FrontPanelUnavailableError as exc:
+        console.print(str(exc))
+        return EXIT_SDK_UNAVAILABLE
+    except DeviceDiscoveryError as exc:
+        console.print(str(exc))
+        return EXIT_DISCOVERY_ERROR
+
+    if not devices:
+        console.print("No Opal Kelly FrontPanel devices found.")
+        return EXIT_NO_DEVICES
+
+    table = Table(title="Opal Kelly Devices")
+    table.add_column("device_id")
+    table.add_column("model")
+    table.add_column("serial")
+
+    for device in devices:
+        table.add_row(
+            device.device_id,
+            device.model,
+            device.serial,
+        )
+
+    console.print(table)
     return 0
 
 
@@ -119,6 +162,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Check whether the FrontPanel SDK can be imported",
     )
     check_sdk_parser.set_defaults(handler=_check_sdk)
+
+    devices_parser = subparsers.add_parser(
+        "devices",
+        help="List attached Opal Kelly FrontPanel devices",
+    )
+    devices_parser.set_defaults(handler=_list_devices)
 
     setup_parser = subparsers.add_parser(
         "setup-frontpanel",

--- a/mms_ok/cli.py
+++ b/mms_ok/cli.py
@@ -11,6 +11,7 @@ from .ok_setup import (
     DEFAULT_FRONTPANEL_DIR,
     DEFAULT_LIB_DIR,
     copy_frontpanel_files,
+    frontpanel_cache_status,
     get_frontpanel_version,
     import_ok,
     reset_frontpanel_cache,
@@ -31,6 +32,11 @@ def _run_bist(_args) -> int:
 
 
 def _setup_frontpanel(_args) -> int:
+    cache = frontpanel_cache_status(DEFAULT_LIB_DIR)
+    if cache["complete"]:
+        print(f"FrontPanel files already set up at: {cache['path']}")
+        return 0
+
     target_dir = copy_frontpanel_files()
     message = (
         f"FrontPanel files copied to: {target_dir}"

--- a/mms_ok/cli.py
+++ b/mms_ok/cli.py
@@ -1,10 +1,13 @@
 """Command-line interface for mms_ok."""
 
 import argparse
+import os
+import sys
 from typing import Optional, Sequence
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from . import __version__
 from .devices import (
@@ -12,6 +15,7 @@ from .devices import (
     FrontPanelUnavailableError,
     list_devices,
 )
+from .display import MMS_OK_LOGO
 from .doctor import run_doctor
 from .ok_setup import (
     DEFAULT_FRONTPANEL_DIR,
@@ -33,6 +37,21 @@ LOCK_GUIDANCE = (
 EXIT_SDK_UNAVAILABLE = 1
 EXIT_NO_DEVICES = 2
 EXIT_DISCOVERY_ERROR = 3
+
+
+MENU_COMMANDS = (
+    ("doctor", "Inspect SDK, cache, and Jupyter visibility"),
+    ("check-sdk", "Verify FrontPanel import"),
+    ("setup-frontpanel", "Copy SDK Python files"),
+    ("devices", "List connected boards"),
+    ("bist", "Run board self-test"),
+)
+
+KEY_UP = "up"
+KEY_DOWN = "down"
+KEY_ENTER = "enter"
+KEY_QUIT = "quit"
+KEY_UNKNOWN = "unknown"
 
 
 def _run_bist(_args) -> int:
@@ -210,7 +229,127 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _read_menu_key() -> str:
+    if os.name == "nt" and sys.stdin.isatty():
+        import msvcrt
+
+        key = msvcrt.getwch()
+        if key in ("\x00", "\xe0"):
+            key = msvcrt.getwch()
+            if key == "H":
+                return KEY_UP
+            if key == "P":
+                return KEY_DOWN
+            return KEY_UNKNOWN
+    elif sys.stdin.isatty():
+        import select
+        import termios
+        import tty
+
+        fd = sys.stdin.fileno()
+        settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            key = sys.stdin.read(1)
+            if key == "\x1b":
+                ready, _, _ = select.select([sys.stdin], [], [], 0.05)
+                if ready:
+                    sequence = sys.stdin.read(2)
+                    if sequence == "[A":
+                        return KEY_UP
+                    if sequence == "[B":
+                        return KEY_DOWN
+                return KEY_QUIT
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, settings)
+    else:
+        key = sys.stdin.read(1)
+        if key == "":
+            raise EOFError
+        if key == "\x1b":
+            sequence = sys.stdin.read(2)
+            if sequence == "[A":
+                return KEY_UP
+            if sequence == "[B":
+                return KEY_DOWN
+            return KEY_QUIT
+
+    if key in ("\r", "\n"):
+        return KEY_ENTER
+    if key in ("q", "Q", "\x1b", "\x03"):
+        return KEY_QUIT
+    return KEY_UNKNOWN
+
+
+def _render_interactive_menu(console: Console, selected: int, message: str = "") -> None:
+    console.clear()
+    console.print(MMS_OK_LOGO, style="bold white")
+    console.print()
+    console.print(Text("https://github.com/ojy0216/mms_ok", style="white"))
+    console.print("FrontPanel setup and board diagnostics.")
+    console.print()
+    title_line = Text()
+    title_line.append("mms_ok setup helper", style="bold")
+    title_line.append(f"  v{__version__}", style="dim")
+    console.print(title_line)
+
+    for index, (command, description) in enumerate(MENU_COMMANDS):
+        pointer = ">" if index == selected else " "
+        command_style = "bold cyan" if index == selected else "bold white"
+        description_style = "cyan" if index == selected else "white"
+        console.print(
+            f"{pointer} {index + 1}. ",
+            f"[{command_style}]{command:<17}[/] ",
+            f"[{description_style}]{description}[/]",
+            sep="",
+        )
+
+    console.print()
+    console.print("[dim]Up/Down  |  Enter Run  |  Q Quit[/dim]")
+
+    if message:
+        console.print()
+        console.print(message, style="yellow")
+
+
+def _run_interactive_menu() -> int:
+    console = Console(highlight=False)
+    selected = 0
+    message = ""
+
+    while True:
+        _render_interactive_menu(console, selected, message)
+        try:
+            key = _read_menu_key()
+        except (EOFError, KeyboardInterrupt):
+            console.print()
+            return 0
+
+        if key == KEY_QUIT:
+            return 0
+        if key == KEY_UP:
+            selected = (selected - 1) % len(MENU_COMMANDS)
+            message = ""
+            continue
+        if key == KEY_DOWN:
+            selected = (selected + 1) % len(MENU_COMMANDS)
+            message = ""
+            continue
+        if key == KEY_ENTER:
+            command = MENU_COMMANDS[selected][0]
+            console.clear()
+            return main([command])
+
+        message = "Use the arrow keys, Enter, or q."
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if len(argv) == 0:
+        return _run_interactive_menu()
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/mms_ok/cli.py
+++ b/mms_ok/cli.py
@@ -3,9 +3,25 @@
 import argparse
 from typing import Optional, Sequence
 
-from . import __version__
-from .ok_setup import copy_frontpanel_files, get_frontpanel_version, import_ok
+from rich.console import Console
 
+from . import __version__
+from .doctor import run_doctor
+from .ok_setup import (
+    DEFAULT_FRONTPANEL_DIR,
+    DEFAULT_LIB_DIR,
+    copy_frontpanel_files,
+    get_frontpanel_version,
+    import_ok,
+    reset_frontpanel_cache,
+    resolve_path,
+)
+
+
+LOCK_GUIDANCE = (
+    "Close or restart Python processes, IPython/Jupyter kernels, notebooks, IDE "
+    "terminals, or anything importing ok/_ok.pyd, then retry."
+)
 
 def _run_bist(_args) -> int:
     from . import BIST
@@ -42,6 +58,46 @@ def _check_sdk(_args) -> int:
     return 0
 
 
+def _run_doctor(args) -> int:
+    return run_doctor(
+        frontpanel_dir=args.frontpanel_dir,
+        lib_dir=args.lib_dir,
+    )
+
+
+def _reset_cache(args) -> int:
+    frontpanel_dir = resolve_path(args.frontpanel_dir)
+    lib_dir = resolve_path(args.lib_dir)
+    console = Console()
+
+    try:
+        target_dir = reset_frontpanel_cache(
+            frontpanel_dir=frontpanel_dir,
+            lib_dir=lib_dir,
+        )
+    except PermissionError as exc:
+        console.print("FrontPanel cache refresh failed: {}".format(exc))
+        console.print(LOCK_GUIDANCE)
+        return 1
+    except FileNotFoundError as exc:
+        console.print("FrontPanel SDK files were not found: {}".format(exc))
+        console.print(
+            "Checked SDK path: {}. Install the SDK or pass --frontpanel-dir.".format(
+                frontpanel_dir
+            )
+        )
+        return 1
+
+    if target_dir is None:
+        console.print("FrontPanel cache refresh failed.")
+        console.print("Checked SDK path: {}".format(frontpanel_dir))
+        console.print("Resolved cache path: {}".format(lib_dir))
+        return 1
+
+    console.print("FrontPanel cache refreshed: {}".format(target_dir))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="mms_ok")
     subparsers = parser.add_subparsers(dest="command")
@@ -63,6 +119,38 @@ def build_parser() -> argparse.ArgumentParser:
         help="Copy FrontPanel Python files into the default local directory",
     )
     setup_parser.set_defaults(handler=_setup_frontpanel)
+
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Diagnose FrontPanel SDK setup and runtime visibility",
+    )
+    doctor_parser.add_argument(
+        "--frontpanel-dir",
+        default=DEFAULT_FRONTPANEL_DIR,
+        help="FrontPanel SDK directory to inspect",
+    )
+    doctor_parser.add_argument(
+        "--lib-dir",
+        default=DEFAULT_LIB_DIR,
+        help="Local FrontPanel cache directory to inspect",
+    )
+    doctor_parser.set_defaults(handler=_run_doctor)
+
+    reset_cache_parser = subparsers.add_parser(
+        "reset-cache",
+        help="Refresh cached FrontPanel Python files",
+    )
+    reset_cache_parser.add_argument(
+        "--frontpanel-dir",
+        default=DEFAULT_FRONTPANEL_DIR,
+        help="FrontPanel SDK directory to copy from",
+    )
+    reset_cache_parser.add_argument(
+        "--lib-dir",
+        default=DEFAULT_LIB_DIR,
+        help="Local FrontPanel cache directory to refresh",
+    )
+    reset_cache_parser.set_defaults(handler=_reset_cache)
 
     return parser
 

--- a/mms_ok/devices.py
+++ b/mms_ok/devices.py
@@ -1,0 +1,109 @@
+"""FrontPanel device discovery helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
+
+from .ok_setup import import_ok
+
+
+class FrontPanelUnavailableError(RuntimeError):
+    """Raised when the FrontPanel SDK cannot be imported."""
+
+
+class DeviceDiscoveryError(RuntimeError):
+    """Raised when device enumeration fails unexpectedly."""
+
+
+@dataclass(frozen=True)
+class DeviceInfo:
+    """Public representation of an attached FrontPanel device."""
+
+    serial: str
+    model: str
+    device_id: str
+    product_id: int
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _close_frontpanel(handle: Any) -> None:
+    try:
+        if bool(handle.IsOpen()):
+            handle.Close()
+    except Exception:
+        try:
+            handle.Close()
+        except Exception:
+            pass
+
+
+def _to_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _get_device_info(ok: Any, serial: str, model: str) -> DeviceInfo:
+    handle = ok.okCFrontPanel()
+    opened = False
+
+    try:
+        error_code = handle.OpenBySerial(serial)
+        if error_code != 0:
+            raise DeviceDiscoveryError(
+                "Could not open device with serial {!r} while reading device info "
+                "(OpenBySerial returned {}).".format(serial, error_code)
+            )
+        opened = True
+
+        raw_info = ok.okTDeviceInfo()
+        handle.GetDeviceInfo(raw_info)
+
+        return DeviceInfo(
+            serial=_to_text(getattr(raw_info, "serialNumber", serial)),
+            model=_to_text(getattr(raw_info, "productName", model)),
+            device_id=_to_text(getattr(raw_info, "deviceID", "")),
+            product_id=int(getattr(raw_info, "productID", 0)),
+        )
+    finally:
+        if opened:
+            _close_frontpanel(handle)
+
+
+def list_devices() -> List[DeviceInfo]:
+    """Return attached Opal Kelly devices.
+
+    The FrontPanel SDK import is intentionally lazy so ``import mms_ok`` remains
+    usable on machines where the SDK is not installed.
+    """
+
+    try:
+        ok = import_ok()
+    except ImportError as exc:
+        raise FrontPanelUnavailableError(
+            "FrontPanel SDK is not available. Run `mms_ok check-sdk` or "
+            "`mms_ok setup-frontpanel` to diagnose the SDK installation."
+        ) from exc
+
+    try:
+        discovery = ok.okCFrontPanel()
+        device_count = discovery.GetDeviceCount()
+        devices = []
+
+        for index in range(device_count):
+            serial = _to_text(discovery.GetDeviceListSerial(index))
+            model = _to_text(discovery.GetDeviceListModel(index))
+            devices.append(_get_device_info(ok, serial, model))
+
+        return devices
+    except DeviceDiscoveryError:
+        raise
+    except Exception as exc:
+        raise DeviceDiscoveryError(
+            "Unexpected error while discovering FrontPanel devices: {}: {}".format(
+                type(exc).__name__, exc
+            )
+        ) from exc

--- a/mms_ok/doctor.py
+++ b/mms_ok/doctor.py
@@ -1,0 +1,170 @@
+"""FrontPanel diagnostics command implementation."""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+from rich.table import Table
+
+from .ok_setup import (
+    frontpanel_cache_status,
+    get_frontpanel_version,
+    probe_frontpanel_import,
+    python_bitness,
+    resolve_path,
+)
+
+
+STATUS_PASS = "[✅]"
+STATUS_FAIL = "[❌]"
+STATUS_WARN = "[!]"
+
+
+def _get_device_count(ok_module):
+    try:
+        frontpanel = ok_module.okCFrontPanel()
+        return frontpanel.GetDeviceCount(), None
+    except Exception as exc:
+        return None, "{}: {}".format(type(exc).__name__, exc)
+
+
+def _add_doctor_row(table, status, check, result, details=""):
+    table.add_row(status, check, result, details)
+
+
+def run_doctor(frontpanel_dir: str, lib_dir: str) -> int:
+    frontpanel_dir = resolve_path(frontpanel_dir)
+    lib_dir = resolve_path(lib_dir)
+    cache = frontpanel_cache_status(lib_dir)
+    probe = probe_frontpanel_import(lib_dir)
+    ok_module = probe["ok_module"]
+    sdk_exists = os.path.isdir(frontpanel_dir)
+    pyd_present = cache["files"]["_ok.pyd"]["exists"]
+
+    api_version = "unavailable"
+    device_count = "unavailable"
+    device_error = None
+    device_status = STATUS_FAIL
+    if ok_module is not None:
+        api_version = get_frontpanel_version(ok_module)
+        device_count, device_error = _get_device_count(ok_module)
+        if device_count is None:
+            device_count = "unavailable"
+        elif device_count == 0:
+            device_status = STATUS_WARN
+        else:
+            device_status = STATUS_PASS
+
+    table = Table(title="FrontPanel Diagnostics", show_header=True)
+    table.add_column("Status", justify="center", no_wrap=True)
+    table.add_column("Check", style="cyan", no_wrap=True)
+    table.add_column("Result")
+    table.add_column("Details", overflow="fold")
+
+    cache_state = "complete"
+    if cache["partial"]:
+        cache_state = "partial"
+    elif cache["missing"]:
+        cache_state = "missing"
+
+    _add_doctor_row(
+        table,
+        STATUS_PASS if sdk_exists else STATUS_FAIL,
+        "SDK path",
+        "found" if sdk_exists else "missing",
+        frontpanel_dir,
+    )
+    cache_status = STATUS_PASS
+    if cache["partial"]:
+        cache_status = STATUS_WARN
+    elif cache["missing"]:
+        cache_status = STATUS_FAIL
+    _add_doctor_row(table, cache_status, "Local cache", cache_state, cache["path"])
+    for filename, info in cache["files"].items():
+        _add_doctor_row(
+            table,
+            STATUS_PASS if info["exists"] else STATUS_FAIL,
+            "Cache file",
+            "present" if info["exists"] else "missing",
+            "{}: {}".format(filename, info["path"]),
+        )
+    bitness = python_bitness()
+    _add_doctor_row(
+        table,
+        STATUS_PASS if bitness == 64 else STATUS_FAIL,
+        "Python bitness",
+        "{}-bit".format(bitness),
+        "x64 FrontPanel files require 64-bit Python",
+    )
+    _add_doctor_row(
+        table,
+        STATUS_PASS if pyd_present and probe["_ok_imported"] else STATUS_FAIL,
+        "_ok native module",
+        "present/imported"
+        if pyd_present and probe["_ok_imported"]
+        else "present/import failed"
+        if pyd_present
+        else "missing",
+        probe["_ok_error"] or cache["files"]["_ok.pyd"]["path"],
+    )
+    _add_doctor_row(
+        table,
+        STATUS_PASS if probe["ok_imported"] else STATUS_FAIL,
+        "ok import",
+        "imported" if probe["ok_imported"] else "failed",
+        probe["ok_error"] or ("used local cache" if probe["used_cache_path"] else ""),
+    )
+    _add_doctor_row(
+        table,
+        STATUS_PASS if ok_module is not None else STATUS_FAIL,
+        "FrontPanel API",
+        str(api_version),
+        "",
+    )
+    _add_doctor_row(
+        table,
+        device_status,
+        "Device count",
+        str(device_count),
+        device_error or "queried via ok.okCFrontPanel",
+    )
+
+    guidance = []
+    if not sdk_exists:
+        guidance.append(
+            "FrontPanel SDK path is missing. Install the Opal Kelly FrontPanel SDK "
+            "or pass --frontpanel-dir to the installed SDK path."
+        )
+    if cache["partial"] or cache["missing"]:
+        guidance.append(
+            "Local cache is not complete. Run `mms_ok reset-cache` after confirming "
+            "the SDK path is correct."
+        )
+    if not probe["ok_imported"]:
+        guidance.append(
+            "The ok module could not be imported. Use 64-bit Python with the x64 "
+            "FrontPanel files, refresh the cache, and ensure ok/_ok.pyd is not locked."
+        )
+    if pyd_present and not probe["_ok_imported"]:
+        guidance.append(
+            "_ok.pyd exists but did not import directly. This usually indicates a DLL "
+            "load/path mismatch or a Python bitness mismatch."
+        )
+    if probe["ok_imported"] and device_error is not None:
+        guidance.append(
+            "The ok module imported, but FrontPanel API probing failed: {}. Check "
+            "for an unrelated ok package earlier on sys.path or a broken FrontPanel "
+            "runtime.".format(device_error)
+        )
+    if not guidance:
+        guidance.append("No critical FrontPanel setup issue detected.")
+
+    console = Console()
+    console.print(table)
+    console.print("\nActionable guidance:")
+    for item in guidance:
+        console.print("- {}".format(item))
+
+    critical_failure = not probe["ok_imported"] or device_error is not None
+    return 1 if critical_failure else 0

--- a/mms_ok/doctor.py
+++ b/mms_ok/doctor.py
@@ -6,6 +6,7 @@ import os
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from .ok_setup import (
     frontpanel_cache_status,
@@ -16,9 +17,22 @@ from .ok_setup import (
 )
 
 
-STATUS_PASS = "[✅]"
-STATUS_FAIL = "[❌]"
+STATUS_PASS = "[O]"
+STATUS_FAIL = "[X]"
 STATUS_WARN = "[!]"
+STATUS_STYLES = {
+    STATUS_PASS: "green",
+    STATUS_FAIL: "red",
+    STATUS_WARN: "yellow",
+}
+CRITICAL_CHECKS = {
+    "SDK path",
+    "Python bitness",
+    "_ok native module",
+    "ok import",
+    "FrontPanel API",
+    "Device count",
+}
 
 
 def _get_device_count(ok_module):
@@ -30,7 +44,11 @@ def _get_device_count(ok_module):
 
 
 def _add_doctor_row(table, status, check, result, details=""):
-    table.add_row(status, check, result, details)
+    table.add_row(Text(status, style=STATUS_STYLES[status]), check, result, details)
+
+
+def _append_doctor_row(rows, status, check, result, details=""):
+    rows.append((status, check, result, details))
 
 
 def run_doctor(frontpanel_dir: str, lib_dir: str) -> int:
@@ -68,67 +86,68 @@ def run_doctor(frontpanel_dir: str, lib_dir: str) -> int:
     elif cache["missing"]:
         cache_state = "missing"
 
-    _add_doctor_row(
-        table,
+    rows = []
+    _append_doctor_row(
+        rows,
         STATUS_PASS if sdk_exists else STATUS_FAIL,
         "SDK path",
         "found" if sdk_exists else "missing",
         frontpanel_dir,
     )
     cache_status = STATUS_PASS
-    if cache["partial"]:
+    if cache["partial"] or cache["missing"]:
         cache_status = STATUS_WARN
-    elif cache["missing"]:
-        cache_status = STATUS_FAIL
-    _add_doctor_row(table, cache_status, "Local cache", cache_state, cache["path"])
+    _append_doctor_row(rows, cache_status, "Local cache", cache_state, cache["path"])
     for filename, info in cache["files"].items():
-        _add_doctor_row(
-            table,
-            STATUS_PASS if info["exists"] else STATUS_FAIL,
+        _append_doctor_row(
+            rows,
+            STATUS_PASS if info["exists"] else STATUS_WARN,
             "Cache file",
             "present" if info["exists"] else "missing",
             "{}: {}".format(filename, info["path"]),
         )
     bitness = python_bitness()
-    _add_doctor_row(
-        table,
+    _append_doctor_row(
+        rows,
         STATUS_PASS if bitness == 64 else STATUS_FAIL,
         "Python bitness",
         "{}-bit".format(bitness),
         "x64 FrontPanel files require 64-bit Python",
     )
-    _add_doctor_row(
-        table,
-        STATUS_PASS if pyd_present and probe["_ok_imported"] else STATUS_FAIL,
+    _append_doctor_row(
+        rows,
+        STATUS_PASS if probe["_ok_imported"] else STATUS_FAIL,
         "_ok native module",
-        "present/imported"
-        if pyd_present and probe["_ok_imported"]
+        "imported"
+        if probe["_ok_imported"]
         else "present/import failed"
         if pyd_present
-        else "missing",
+        else "not importable",
         probe["_ok_error"] or cache["files"]["_ok.pyd"]["path"],
     )
-    _add_doctor_row(
-        table,
+    _append_doctor_row(
+        rows,
         STATUS_PASS if probe["ok_imported"] else STATUS_FAIL,
         "ok import",
         "imported" if probe["ok_imported"] else "failed",
         probe["ok_error"] or ("used local cache" if probe["used_cache_path"] else ""),
     )
-    _add_doctor_row(
-        table,
+    _append_doctor_row(
+        rows,
         STATUS_PASS if ok_module is not None else STATUS_FAIL,
         "FrontPanel API",
         str(api_version),
         "",
     )
-    _add_doctor_row(
-        table,
+    _append_doctor_row(
+        rows,
         device_status,
         "Device count",
         str(device_count),
         device_error or "queried via ok.okCFrontPanel",
     )
+    for row in rows:
+        _add_doctor_row(table, *row)
 
     guidance = []
     if not sdk_exists:
@@ -138,8 +157,8 @@ def run_doctor(frontpanel_dir: str, lib_dir: str) -> int:
         )
     if cache["partial"] or cache["missing"]:
         guidance.append(
-            "Local cache is not complete. Run `mms_ok reset-cache` after confirming "
-            "the SDK path is correct."
+            "Optional local cache is not complete. If imports rely on the cache, "
+            "run `mms_ok reset-cache` after confirming the SDK path is correct."
         )
     if not probe["ok_imported"]:
         guidance.append(
@@ -166,5 +185,8 @@ def run_doctor(frontpanel_dir: str, lib_dir: str) -> int:
     for item in guidance:
         console.print("- {}".format(item))
 
-    critical_failure = not probe["ok_imported"] or device_error is not None
+    critical_failure = any(
+        status == STATUS_FAIL and check in CRITICAL_CHECKS
+        for status, check, _result, _details in rows
+    )
     return 1 if critical_failure else 0

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -154,7 +154,8 @@ class XEM(ABC):
             message = (
                 "Bitstream file not found. Pass an absolute path, or pass a "
                 "bitstream filename to load from ../bitstreams relative to the "
-                "current working directory. "
+                "current working directory. Relative paths with directories "
+                "are loaded relative to the current working directory. "
                 "Checked: {}".format(checked)
             )
             log_critical(message)

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -5,10 +5,15 @@ import time
 import types
 import weakref
 from abc import ABC, abstractmethod
-from typing import Optional, Type, Union
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, Optional, Type, Union
 
 import numpy as np
 from loguru import logger
+from rich import box
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
 
 from . import __version__
 from .diagnostics import log_critical, log_error
@@ -231,6 +236,94 @@ class XEM(ABC):
         Return whether the underlying FrontPanel device handle is open.
         """
         return bool(self.xem.IsOpen())
+
+    def diagnostics(
+        self,
+        *,
+        console: Optional[Console] = None,
+        print_output: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Return and optionally print FPGA runtime diagnostics.
+
+        The returned dictionary is intended for tests and scripts. The default
+        printed output is a Rich panel/table for interactive use.
+        """
+        config = self.config
+        board = asdict(config) if is_dataclass(config) else dict(vars(config))
+
+        try:
+            is_open = bool(self.xem.IsOpen())
+        except Exception as exc:
+            is_open = "error: {}: {}".format(type(exc).__name__, exc)
+
+        data = {
+            "board": board,
+            "frontpanel": {
+                "version": getattr(self, "_frontpanel_version", "unknown"),
+                "is_open": is_open,
+            },
+            "bitstream": {
+                "path": getattr(self, "_bitstream_path", None),
+                "timestamp": getattr(self, "_bitstream_timestamp", None),
+            },
+            "endpoints": {
+                "wire": {
+                    "width": getattr(config, "wire_width", None),
+                    "auto_wire_in": getattr(self, "auto_wire_in", None),
+                    "auto_wire_out": getattr(self, "auto_wire_out", None),
+                },
+                "trigger": {
+                    "width": getattr(config, "trigger_width", None),
+                    "auto_trigger_out": getattr(self, "auto_trigger_out", None),
+                },
+                "pipe": {
+                    "width": getattr(config, "pipe_width", None),
+                },
+                "block_pipe": {
+                    "max_block_size": getattr(config, "max_bt_blocksize", None),
+                },
+            },
+        }
+
+        vadj_voltage_dict = getattr(self, "_vadj_voltage_dict", None)
+        if vadj_voltage_dict is not None:
+            data["board"]["vadj_voltage"] = vadj_voltage_dict
+
+        if print_output:
+            output_console = console or Console()
+            output_console.print(self._diagnostics_panel(data))
+
+        return data
+
+    @staticmethod
+    def _diagnostics_panel(data: Dict[str, Any]) -> Panel:
+        board_table = Table(title="Board", show_header=False, box=box.ASCII)
+        board_table.add_column("Field", style="cyan", no_wrap=True)
+        board_table.add_column("Value")
+        for key, value in data["board"].items():
+            board_table.add_row(str(key), str(value))
+
+        runtime_table = Table(title="Runtime", show_header=False, box=box.ASCII)
+        runtime_table.add_column("Field", style="cyan", no_wrap=True)
+        runtime_table.add_column("Value")
+        runtime_table.add_row("FrontPanel version", str(data["frontpanel"]["version"]))
+        runtime_table.add_row("IsOpen", str(data["frontpanel"]["is_open"]))
+        runtime_table.add_row("Bitstream path", str(data["bitstream"]["path"]))
+
+        endpoint_table = Table(title="Endpoints", show_header=True, box=box.ASCII)
+        endpoint_table.add_column("Type", style="cyan", no_wrap=True)
+        endpoint_table.add_column("Setting")
+        endpoint_table.add_column("Value")
+        for endpoint_type, settings in data["endpoints"].items():
+            for setting, value in settings.items():
+                endpoint_table.add_row(endpoint_type, setting, str(value))
+
+        return Panel(
+            Group(board_table, runtime_table, endpoint_table),
+            title="FPGA Diagnostics",
+            box=box.ASCII,
+        )
 
     def close(self) -> None:
         """

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import time
 import types
+import weakref
 from abc import ABC, abstractmethod
 from typing import Optional, Type, Union
 
@@ -64,41 +65,66 @@ class XEM(ABC):
         """
         self._led_used = False
         self._led_address = None
+        self._opened = False
+        self._close_finalizer = None
         ok = get_ok()
         self.xem = ok.okCFrontPanel()
+        self._close_finalizer = weakref.finalize(
+            self, self._finalize_xem_handle, self.xem
+        )
         self._frontpanel_version = get_frontpanel_version(ok)
 
-        self._bitstream_path = os.path.abspath(bitstream_path)
-        self._validate_bitstream_path()
+        try:
+            self._bitstream_path = os.path.abspath(bitstream_path)
+            self._validate_bitstream_path()
 
-        self._connect()
-        self._configure()
+            self._connect()
+            self._configure()
 
-        self.auto_wire_in = True
-        self.auto_wire_out = True
-        self.auto_trigger_out = True
+            self.auto_wire_in = True
+            self.auto_wire_out = True
+            self.auto_trigger_out = True
 
-        self.verbose_level = 0
+            self.verbose_level = 0
 
-        # Initialize components
-        self.wire_ops = WireOperations(self.xem, self.config.wire_width)
-        self.trigger_ops = TriggerOperations(self.xem, self.config.trigger_width)
-        self.pipe_ops = PipeOperations(self.xem)
-        self.block_pipe_ops = BlockPipeOperations(
-            self.xem, self.config.max_bt_blocksize
-        )
+            # Initialize components
+            self.wire_ops = WireOperations(self.xem, self.config.wire_width)
+            self.trigger_ops = TriggerOperations(self.xem, self.config.trigger_width)
+            self.pipe_ops = PipeOperations(self.xem)
+            self.block_pipe_ops = BlockPipeOperations(
+                self.xem, self.config.max_bt_blocksize
+            )
 
-        self._check_device_settings()
+            self._check_device_settings()
 
-        print_fpga_overview(
-            version=__version__,
-            frontpanel_version=self._frontpanel_version,
-            bitstream_path=self._bitstream_path,
-            bitstream_timestamp=self._bitstream_timestamp,
-            config=self.config,
-            vadj_voltage_dict=getattr(self, "_vadj_voltage_dict", None),
-        )
-    
+            print_fpga_overview(
+                version=__version__,
+                frontpanel_version=self._frontpanel_version,
+                bitstream_path=self._bitstream_path,
+                bitstream_timestamp=self._bitstream_timestamp,
+                config=self.config,
+                vadj_voltage_dict=getattr(self, "_vadj_voltage_dict", None),
+            )
+        except Exception:
+            if self._opened:
+                self.close()
+            else:
+                self._detach_close_finalizer()
+            raise
+
+    @staticmethod
+    def _finalize_xem_handle(xem) -> None:
+        try:
+            if bool(xem.IsOpen()):
+                xem.Close()
+        except Exception:
+            pass
+
+    def _detach_close_finalizer(self) -> None:
+        finalizer = getattr(self, "_close_finalizer", None)
+        if finalizer is not None and finalizer.alive:
+            finalizer.detach()
+
     def _validate_bitstream_path(self) -> None:
         """
         Validates the bitstream path and checks if it is a valid bitstream file.
@@ -142,6 +168,7 @@ class XEM(ABC):
         if self.xem.OpenBySerial(""):
             log_critical("Device is not opened!")
             raise ConnectionError("Device is not opened!")
+        self._opened = True
 
         device_info = ok.okTDeviceInfo()
         self.xem.GetDeviceInfo(device_info)
@@ -199,11 +226,35 @@ class XEM(ABC):
         """
         return self
 
+    def is_open(self) -> bool:
+        """
+        Return whether the underlying FrontPanel device handle is open.
+        """
+        return bool(self.xem.IsOpen())
+
     def close(self) -> None:
         """
         Close the FPGA device.
         """
-        self.__exit__(None, None, None)
+        if not getattr(self, "_opened", False):
+            self._detach_close_finalizer()
+            return
+
+        if not self.is_open():
+            self._opened = False
+            self._detach_close_finalizer()
+            return
+
+        logger.info("Closing device")
+        if self._led_used:
+            logger.info("Turning off the LEDs before closing the device!")
+            self.SetLED(led_value=0, led_address=self._led_address)
+        try:
+            self.xem.Close()
+        finally:
+            self._opened = False
+            self._detach_close_finalizer()
+        logger.info("Device closed!")
 
     def __exit__(
         self,
@@ -222,12 +273,7 @@ class XEM(ABC):
         Returns:
             None
         """
-        logger.info("Closing device")
-        if self._led_used:
-            logger.info("Turning off the LEDs before closing the device!")
-            self.SetLED(led_value=0, led_address=self._led_address)
-        self.xem.Close()
-        logger.info("Device closed!")
+        self.close()
     
     def set_verbose_level(self, verbose_level: int) -> None:
         """
@@ -674,16 +720,20 @@ class XEM7310(XEM):
             Plus all exceptions from parent class __init__
         """
         super().__init__(bitstream_path=bitstream_path)
-        ok = get_ok()
+        try:
+            ok = get_ok()
 
-        target_product_id_list = [
-            ok.okCFrontPanel.brdXEM7310A75,
-            ok.okCFrontPanel.brdXEM7310A200,
-        ]
+            target_product_id_list = [
+                ok.okCFrontPanel.brdXEM7310A75,
+                ok.okCFrontPanel.brdXEM7310A200,
+            ]
 
-        if self.config.product_id not in target_product_id_list:
-            log_critical("Connected FPGA board is not a XEM7310A75/A100!")
-            raise TypeError("Connected FPGA board is not a XEM7310A75/A100!")
+            if self.config.product_id not in target_product_id_list:
+                log_critical("Connected FPGA board is not a XEM7310A75/A100!")
+                raise TypeError("Connected FPGA board is not a XEM7310A75/A100!")
+        except Exception:
+            self.close()
+            raise
 
     def _check_device_settings(self) -> None:
         """No additional settings to check for XEM7310."""
@@ -738,13 +788,17 @@ class XEM7360(XEM):
             Plus all exceptions from parent class __init__
         """
         super().__init__(bitstream_path=bitstream_path)
-        ok = get_ok()
+        try:
+            ok = get_ok()
 
-        target_product_id = ok.okCFrontPanel.brdXEM7360K160T
+            target_product_id = ok.okCFrontPanel.brdXEM7360K160T
 
-        if self.config.product_id != target_product_id:
-            log_critical("Connected FPGA board is not a XEM7360K160T!")
-            raise TypeError("Connected FPGA board is not a XEM7360K160T!")
+            if self.config.product_id != target_product_id:
+                log_critical("Connected FPGA board is not a XEM7360K160T!")
+                raise TypeError("Connected FPGA board is not a XEM7360K160T!")
+        except Exception:
+            self.close()
+            raise
 
     def _check_device_settings(self) -> None:
         """

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from . import __version__
+from .bitstreams import format_checked_paths, resolve_user_bitstream_path
 from .diagnostics import log_critical, log_error
 from .display import print_fpga_overview
 from .fpga_components import (
@@ -80,7 +81,9 @@ class XEM(ABC):
         self._frontpanel_version = get_frontpanel_version(ok)
 
         try:
-            self._bitstream_path = os.path.abspath(bitstream_path)
+            resolution = resolve_user_bitstream_path(bitstream_path)
+            self._bitstream_path = resolution.path
+            self._checked_bitstream_paths = resolution.checked_paths
             self._validate_bitstream_path()
 
             self._connect()
@@ -145,8 +148,16 @@ class XEM(ABC):
             ValueError: If the bitstream file extension is not ".bit".
         """
         if not os.path.isfile(self._bitstream_path):
-            log_critical(f'"{self._bitstream_path}" is invalid!')
-            raise FileNotFoundError(f"{self._bitstream_path} is an invalid bitstream!")
+            checked = format_checked_paths(
+                getattr(self, "_checked_bitstream_paths", [self._bitstream_path])
+            )
+            message = (
+                "Bitstream file not found. Relative paths are resolved from "
+                "../bitstreams relative to the current working directory. "
+                "Checked: {}".format(checked)
+            )
+            log_critical(message)
+            raise FileNotFoundError(message)
 
         extension = os.path.splitext(self._bitstream_path)[1]
         if extension != ".bit":

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -152,8 +152,9 @@ class XEM(ABC):
                 getattr(self, "_checked_bitstream_paths", [self._bitstream_path])
             )
             message = (
-                "Bitstream file not found. Relative paths are resolved from "
-                "../bitstreams relative to the current working directory. "
+                "Bitstream file not found. Pass an absolute path, or pass a "
+                "bitstream filename to load from ../bitstreams relative to the "
+                "current working directory. "
                 "Checked: {}".format(checked)
             )
             log_critical(message)

--- a/mms_ok/ok_setup.py
+++ b/mms_ok/ok_setup.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import shutil
 import sys
+from struct import calcsize
 
 from loguru import logger
 
@@ -31,14 +32,96 @@ def _frontpanel_cache_is_partial(lib_dir: str = DEFAULT_LIB_DIR) -> bool:
     return any(existing_files) and not all(existing_files)
 
 
+def resolve_path(path: str) -> str:
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
+
+
+def frontpanel_file_sources(frontpanel_dir: str = DEFAULT_FRONTPANEL_DIR):
+    frontpanel_dir = resolve_path(frontpanel_dir)
+    return {
+        "ok.py": os.path.join(frontpanel_dir, "API/Python/x64/ok.py"),
+        "_ok.pyd": os.path.join(frontpanel_dir, "API/Python/x64/_ok.pyd"),
+        "okFrontPanel.dll": os.path.join(
+            frontpanel_dir, "API/lib/x64/okFrontPanel.dll"
+        ),
+    }
+
+
+def frontpanel_cache_status(lib_dir: str = DEFAULT_LIB_DIR):
+    lib_dir = resolve_path(lib_dir)
+    files = {
+        name: {
+            "path": os.path.join(lib_dir, name),
+            "exists": os.path.isfile(os.path.join(lib_dir, name)),
+        }
+        for name in FRONTPANEL_FILENAMES
+    }
+    existing_count = sum(1 for info in files.values() if info["exists"])
+    return {
+        "path": lib_dir,
+        "files": files,
+        "complete": existing_count == len(FRONTPANEL_FILENAMES),
+        "partial": 0 < existing_count < len(FRONTPANEL_FILENAMES),
+        "missing": existing_count == 0,
+    }
+
+
+def python_bitness() -> int:
+    return calcsize("P") * 8
+
+
+def probe_frontpanel_import(lib_dir: str = DEFAULT_LIB_DIR):
+    """Probe ok/_ok imports without copying or refreshing FrontPanel files."""
+    lib_dir = resolve_path(lib_dir)
+    result = {
+        "ok_module": None,
+        "ok_imported": False,
+        "_ok_imported": False,
+        "ok_error": None,
+        "_ok_error": None,
+        "used_cache_path": False,
+    }
+
+    try:
+        result["ok_module"] = importlib.import_module("ok")
+        result["ok_imported"] = True
+    except Exception as exc:
+        result["ok_error"] = "{}: {}".format(type(exc).__name__, exc)
+
+    if not result["ok_imported"] and _frontpanel_files_exist(lib_dir):
+        _append_sys_path(lib_dir)
+        result["used_cache_path"] = True
+        try:
+            result["ok_module"] = importlib.import_module("ok")
+            result["ok_imported"] = True
+            result["ok_error"] = None
+        except Exception as exc:
+            result["ok_error"] = "{}: {}".format(type(exc).__name__, exc)
+
+    if os.path.isfile(os.path.join(lib_dir, "_ok.pyd")):
+        _append_sys_path(lib_dir)
+
+    try:
+        importlib.import_module("_ok")
+        result["_ok_imported"] = True
+    except Exception as exc:
+        result["_ok_error"] = "{}: {}".format(type(exc).__name__, exc)
+
+    return result
+
+
 def copy_frontpanel_files(
     frontpanel_dir: str = DEFAULT_FRONTPANEL_DIR,
     lib_dir: str = DEFAULT_LIB_DIR,
     overwrite: bool = False,
+    raise_errors: bool = False,
 ):
     if os.name != "nt":
         logger.info("OS is not Windows!")
         return None
+
+    frontpanel_dir = resolve_path(frontpanel_dir)
+    lib_dir = resolve_path(lib_dir)
 
     if not os.path.exists(frontpanel_dir):
         logger.warning("FrontPanel SDK not found!")
@@ -49,33 +132,43 @@ def copy_frontpanel_files(
 
     try:
         refresh_cache = overwrite or _frontpanel_cache_is_partial(lib_dir)
-        files = {
-            "ok.py": os.path.join(frontpanel_dir, "API/Python/x64/ok.py"),
-            "_ok.pyd": os.path.join(frontpanel_dir, "API/Python/x64/_ok.pyd"),
-            "okFrontPanel.dll": os.path.join(
-                frontpanel_dir, "API/lib/x64/okFrontPanel.dll"
-            ),
-        }
+        files = frontpanel_file_sources(frontpanel_dir)
 
         for filename, source in files.items():
             destination = os.path.join(lib_dir, filename)
             if os.path.exists(destination) and not refresh_cache:
-                logger.debug(f"Using existing FrontPanel file: {destination}")
+                logger.info(f"Using existing FrontPanel file: {destination}")
                 continue
             shutil.copy(src=source, dst=destination)
 
         _append_sys_path(lib_dir)
         return lib_dir
     except FileNotFoundError:
+        if raise_errors:
+            raise
         logger.warning("FrontPanel SDK files not found!")
         logger.warning(f"Default Directory: {frontpanel_dir}")
         return None
     except PermissionError as exc:
+        if raise_errors:
+            raise
         logger.warning(f"FrontPanel SDK file copy failed: {exc}")
         logger.warning(
             "Close other Python/Jupyter processes using FrontPanel, or restart their kernels."
         )
         return None
+
+
+def reset_frontpanel_cache(
+    frontpanel_dir: str = DEFAULT_FRONTPANEL_DIR,
+    lib_dir: str = DEFAULT_LIB_DIR,
+):
+    return copy_frontpanel_files(
+        frontpanel_dir=frontpanel_dir,
+        lib_dir=lib_dir,
+        overwrite=True,
+        raise_errors=True,
+    )
 
 
 def import_ok():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mms_ok"
-version = "2.0.1"
+version = "2.1.0_dev"
 description = "Python package for interfacing with Opal Kelly FPGA boards"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_bitstreams.py
+++ b/tests/test_bitstreams.py
@@ -6,6 +6,33 @@ from mms_ok import bist
 from mms_ok import bitstreams
 
 
+def test_user_resolver_accepts_absolute_bitstream_path(tmp_path):
+    bitstream = tmp_path / "design.bit"
+    bitstream.write_bytes(b"absolute")
+
+    resolution = bitstreams.resolve_user_bitstream_path(str(bitstream))
+
+    assert resolution.path == str(bitstream.resolve())
+    assert resolution.checked_paths == [str(bitstream.resolve())]
+
+
+def test_user_resolver_uses_parent_bitstreams_for_filename(monkeypatch, tmp_path):
+    work_dir = tmp_path / "work"
+    parent_bitstream_dir = tmp_path / "bitstreams"
+    work_dir.mkdir()
+    parent_bitstream_dir.mkdir()
+    cwd_bitstream = work_dir / "design.bit"
+    parent_bitstream = parent_bitstream_dir / "design.bit"
+    cwd_bitstream.write_bytes(b"cwd")
+    parent_bitstream.write_bytes(b"parent")
+    monkeypatch.chdir(work_dir)
+
+    resolution = bitstreams.resolve_user_bitstream_path("design.bit")
+
+    assert resolution.path == str(parent_bitstream.resolve())
+    assert resolution.checked_paths == [str(parent_bitstream.resolve())]
+
+
 def test_bist_resolver_prefers_packaged_bitstream(monkeypatch, tmp_path):
     package_dir = tmp_path / "package"
     legacy_dir = tmp_path / "legacy"
@@ -21,6 +48,22 @@ def test_bist_resolver_prefers_packaged_bitstream(monkeypatch, tmp_path):
 
     assert bist.BIST._resolve_bitstream_path("board.bit") == str(
         package_bitstream.resolve()
+    )
+
+
+def test_bist_resolver_falls_back_to_legacy_bitstream(monkeypatch, tmp_path):
+    package_dir = tmp_path / "package"
+    legacy_dir = tmp_path / "legacy"
+    package_dir.mkdir()
+    legacy_dir.mkdir()
+    legacy_bitstream = legacy_dir / "board.bit"
+    legacy_bitstream.write_bytes(b"legacy")
+
+    monkeypatch.setattr(bitstreams, "PACKAGE_BITSTREAM_DIR", str(package_dir))
+    monkeypatch.setattr(bitstreams, "LEGACY_BITSTREAM_DIR", str(legacy_dir))
+
+    assert bist.BIST._resolve_bitstream_path("board.bit") == str(
+        legacy_bitstream.resolve()
     )
 
 

--- a/tests/test_bitstreams.py
+++ b/tests/test_bitstreams.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from mms_ok import bist
+from mms_ok import bitstreams
+
+
+def test_bist_resolver_prefers_packaged_bitstream(monkeypatch, tmp_path):
+    package_dir = tmp_path / "package"
+    legacy_dir = tmp_path / "legacy"
+    package_dir.mkdir()
+    legacy_dir.mkdir()
+    package_bitstream = package_dir / "board.bit"
+    legacy_bitstream = legacy_dir / "board.bit"
+    package_bitstream.write_bytes(b"package")
+    legacy_bitstream.write_bytes(b"legacy")
+
+    monkeypatch.setattr(bitstreams, "PACKAGE_BITSTREAM_DIR", str(package_dir))
+    monkeypatch.setattr(bitstreams, "LEGACY_BITSTREAM_DIR", str(legacy_dir))
+
+    assert bist.BIST._resolve_bitstream_path("board.bit") == str(
+        package_bitstream.resolve()
+    )
+
+
+def test_bist_resolver_reports_checked_paths(monkeypatch, tmp_path):
+    package_dir = tmp_path / "package"
+    legacy_dir = tmp_path / "legacy"
+
+    monkeypatch.setattr(bitstreams, "PACKAGE_BITSTREAM_DIR", str(package_dir))
+    monkeypatch.setattr(bitstreams, "LEGACY_BITSTREAM_DIR", str(legacy_dir))
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        bist.BIST._resolve_bitstream_path("missing.bit")
+
+    message = str(exc_info.value)
+    assert str((package_dir / "missing.bit").resolve()) in message
+    assert str((legacy_dir / "missing.bit").resolve()) in message

--- a/tests/test_bitstreams.py
+++ b/tests/test_bitstreams.py
@@ -33,6 +33,58 @@ def test_user_resolver_uses_parent_bitstreams_for_filename(monkeypatch, tmp_path
     assert resolution.checked_paths == [str(parent_bitstream.resolve())]
 
 
+def test_user_resolver_uses_cwd_for_directory_relative_path(monkeypatch, tmp_path):
+    work_dir = tmp_path / "work"
+    bitstream_dir = work_dir / "subdir"
+    work_dir.mkdir()
+    bitstream_dir.mkdir()
+    bitstream = bitstream_dir / "design.bit"
+    bitstream.write_bytes(b"relative")
+    monkeypatch.chdir(work_dir)
+
+    resolution = bitstreams.resolve_user_bitstream_path("subdir/design.bit")
+
+    assert resolution.path == str(bitstream.resolve())
+    assert resolution.checked_paths == [str(bitstream.resolve())]
+
+
+def test_user_resolver_uses_cwd_for_current_directory_path(monkeypatch, tmp_path):
+    work_dir = tmp_path / "work"
+    parent_bitstream_dir = tmp_path / "bitstreams"
+    work_dir.mkdir()
+    parent_bitstream_dir.mkdir()
+    cwd_bitstream = work_dir / "design.bit"
+    parent_bitstream = parent_bitstream_dir / "design.bit"
+    cwd_bitstream.write_bytes(b"cwd")
+    parent_bitstream.write_bytes(b"parent")
+    monkeypatch.chdir(work_dir)
+
+    resolution = bitstreams.resolve_user_bitstream_path("./design.bit")
+
+    assert resolution.path == str(cwd_bitstream.resolve())
+    assert resolution.checked_paths == [str(cwd_bitstream.resolve())]
+
+
+def test_user_resolver_expands_env_before_directory_relative_check(
+    monkeypatch, tmp_path
+):
+    work_dir = tmp_path / "work"
+    bitstream_dir = work_dir / "subdir"
+    work_dir.mkdir()
+    bitstream_dir.mkdir()
+    bitstream = bitstream_dir / "design.bit"
+    bitstream.write_bytes(b"env relative")
+    monkeypatch.chdir(work_dir)
+    monkeypatch.setenv("MMS_OK_TEST_BITSTREAM_DIR", "subdir")
+
+    resolution = bitstreams.resolve_user_bitstream_path(
+        "$MMS_OK_TEST_BITSTREAM_DIR/design.bit"
+    )
+
+    assert resolution.path == str(bitstream.resolve())
+    assert resolution.checked_paths == [str(bitstream.resolve())]
+
+
 def test_bist_resolver_prefers_packaged_bitstream(monkeypatch, tmp_path):
     package_dir = tmp_path / "package"
     legacy_dir = tmp_path / "legacy"

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -13,8 +13,17 @@ class FakeFrontPanel:
         return 2
 
 
+class EmptyFrontPanel:
+    def GetDeviceCount(self) -> int:
+        return 0
+
+
 class FakeOk:
     okCFrontPanel = FakeFrontPanel
+
+
+class EmptyOk:
+    okCFrontPanel = EmptyFrontPanel
 
 
 class BrokenFrontPanel:
@@ -234,6 +243,118 @@ def test_doctor_fails_when_frontpanel_api_probe_fails(
     assert "Device count" in captured.out
     assert "frontpanel unavailable" in captured.out
     assert "FrontPanel API probing failed" in captured.out
+
+
+@pytest.mark.parametrize(
+    ("sdk_exists", "cache", "probe"),
+    [
+        (
+            False,
+            lambda path: _cache(path),
+            {
+                "ok_module": FakeOk,
+                "ok_imported": True,
+                "_ok_imported": True,
+                "ok_error": None,
+                "_ok_error": None,
+                "used_cache_path": True,
+            },
+        ),
+        (
+            True,
+            lambda path: _cache(path),
+            {
+                "ok_module": FakeOk,
+                "ok_imported": True,
+                "_ok_imported": False,
+                "ok_error": None,
+                "_ok_error": "ImportError: DLL load failed",
+                "used_cache_path": True,
+            },
+        ),
+    ],
+)
+def test_doctor_fails_when_setup_rows_fail_even_if_ok_import_succeeds(
+    monkeypatch, tmp_path, capsys, sdk_exists, cache, probe
+):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: sdk_exists)
+    monkeypatch.setattr(doctor, "frontpanel_cache_status", cache)
+    monkeypatch.setattr(doctor, "probe_frontpanel_import", lambda path: probe)
+    monkeypatch.setattr(doctor, "get_frontpanel_version", lambda ok: "9.9.9")
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "ok import" in captured.out
+    assert "imported" in captured.out
+
+
+def test_doctor_allows_missing_optional_cache_when_imports_and_api_work(
+    monkeypatch, tmp_path, capsys
+):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: path == sdk_dir)
+    monkeypatch.setattr(
+        doctor, "frontpanel_cache_status", lambda path: _cache(path, complete=False)
+    )
+    monkeypatch.setattr(
+        doctor,
+        "probe_frontpanel_import",
+        lambda path: {
+            "ok_module": FakeOk,
+            "ok_imported": True,
+            "_ok_imported": True,
+            "ok_error": None,
+            "_ok_error": None,
+            "used_cache_path": False,
+        },
+    )
+    monkeypatch.setattr(doctor, "get_frontpanel_version", lambda ok: "9.9.9")
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Local cache" in captured.out
+    assert "Optional local cache is not complete" in captured.out
+    assert "ok import" in captured.out
+    assert "imported" in captured.out
+
+
+def test_doctor_warning_only_zero_devices_exits_success(
+    monkeypatch, tmp_path, capsys
+):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: path == sdk_dir)
+    monkeypatch.setattr(doctor, "frontpanel_cache_status", lambda path: _cache(path))
+    monkeypatch.setattr(
+        doctor,
+        "probe_frontpanel_import",
+        lambda path: {
+            "ok_module": EmptyOk,
+            "ok_imported": True,
+            "_ok_imported": True,
+            "ok_error": None,
+            "_ok_error": None,
+            "used_cache_path": True,
+        },
+    )
+    monkeypatch.setattr(doctor, "get_frontpanel_version", lambda ok: "9.9.9")
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Device count" in captured.out
+    assert "0" in captured.out
 
 
 def test_reset_cache_uses_resolved_default_path(monkeypatch, capsys):

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -53,6 +53,97 @@ def test_help_includes_diagnostics_commands(capsys):
     assert "reset-cache" in captured.out
 
 
+def test_bare_cli_renders_interactive_menu(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_read_menu_key", lambda: cli.KEY_QUIT)
+
+    status = cli.main([])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "mms_ok setup helper" in captured.out
+    assert "check-sdk" in captured.out
+    assert "setup-frontpanel" in captured.out
+    assert "doctor" in captured.out
+    assert "bist" in captured.out
+    assert "version" not in captured.out
+
+
+def test_bare_cli_menu_dispatches_selected_command(monkeypatch):
+    calls = []
+
+    def fake_doctor(args):
+        calls.append(args.command)
+        return 17
+
+    monkeypatch.setattr(cli, "_read_menu_key", lambda: cli.KEY_ENTER)
+    monkeypatch.setattr(cli, "_run_doctor", fake_doctor)
+
+    status = cli.main([])
+
+    assert status == 17
+    assert calls == ["doctor"]
+
+
+def test_bare_cli_menu_arrow_selection_dispatches_command(monkeypatch):
+    calls = []
+    keys = iter([cli.KEY_DOWN, cli.KEY_DOWN, cli.KEY_ENTER])
+
+    def fake_setup_frontpanel(args):
+        calls.append(args.command)
+        return 23
+
+    monkeypatch.setattr(cli, "_read_menu_key", lambda: next(keys))
+    monkeypatch.setattr(cli, "_setup_frontpanel", fake_setup_frontpanel)
+
+    status = cli.main([])
+
+    assert status == 23
+    assert calls == ["setup-frontpanel"]
+
+
+def test_bare_cli_menu_quit_exits_cleanly(monkeypatch):
+    monkeypatch.setattr(cli, "_read_menu_key", lambda: cli.KEY_QUIT)
+
+    assert cli.main([]) == 0
+
+
+def test_bare_cli_menu_eof_exits_cleanly(monkeypatch):
+    def raise_eof():
+        raise EOFError
+
+    monkeypatch.setattr(cli, "_read_menu_key", raise_eof)
+
+    assert cli.main([]) == 0
+
+
+def test_bare_cli_menu_keyboard_interrupt_exits_cleanly(monkeypatch):
+    def raise_keyboard_interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "_read_menu_key", raise_keyboard_interrupt)
+
+    assert cli.main([]) == 0
+
+
+def test_bare_cli_menu_invalid_input_reprompts_without_traceback(monkeypatch, capsys):
+    keys = iter([cli.KEY_UNKNOWN, cli.KEY_QUIT])
+    monkeypatch.setattr(cli, "_read_menu_key", lambda: next(keys))
+
+    status = cli.main([])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Use the arrow keys, Enter, or q." in captured.out
+
+
+def test_existing_version_subcommand_still_dispatches(capsys):
+    status = cli.main(["version"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert captured.out == f"v{cli.__version__}\n"
+
+
 def test_doctor_success_reports_api_and_device_count(monkeypatch, tmp_path, capsys):
     lib_dir = str(tmp_path / "cache")
     sdk_dir = str(tmp_path / "sdk")

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -180,3 +180,41 @@ def test_reset_cache_permission_error_reports_lock_guidance(monkeypatch, capsys)
     assert "file is locked" in captured.out
     assert "IPython/Jupyter kernels" in captured.out
     assert "ok/_ok.pyd" in captured.out
+
+
+def test_setup_frontpanel_reports_existing_complete_cache(
+    monkeypatch, tmp_path, capsys
+):
+    lib_dir = str(tmp_path / "cache")
+
+    def fail_copy():
+        raise AssertionError("copy_frontpanel_files should not be called")
+
+    monkeypatch.setattr(cli, "frontpanel_cache_status", lambda path: _cache(lib_dir))
+    monkeypatch.setattr(cli, "copy_frontpanel_files", fail_copy)
+
+    status = cli.main(["setup-frontpanel"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "already set up" in captured.out
+    assert "FrontPanel files copied" not in captured.out
+    assert lib_dir in captured.out
+
+
+def test_setup_frontpanel_reports_copy_when_cache_is_missing(
+    monkeypatch, tmp_path, capsys
+):
+    lib_dir = str(tmp_path / "cache")
+
+    monkeypatch.setattr(
+        cli, "frontpanel_cache_status", lambda path: _cache(lib_dir, complete=False)
+    )
+    monkeypatch.setattr(cli, "copy_frontpanel_files", lambda: lib_dir)
+
+    status = cli.main(["setup-frontpanel"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "FrontPanel files copied to:" in captured.out
+    assert lib_dir in captured.out

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mms_ok import cli
+from mms_ok import doctor
+
+
+class FakeFrontPanel:
+    def GetDeviceCount(self) -> int:
+        return 2
+
+
+class FakeOk:
+    okCFrontPanel = FakeFrontPanel
+
+
+class BrokenFrontPanel:
+    def GetDeviceCount(self) -> int:
+        raise RuntimeError("frontpanel unavailable")
+
+
+class BrokenOk:
+    okCFrontPanel = BrokenFrontPanel
+
+
+def _cache(path, complete=True, partial=False):
+    return {
+        "path": path,
+        "complete": complete,
+        "partial": partial,
+        "missing": not complete and not partial,
+        "files": {
+            "ok.py": {"path": os.path.join(path, "ok.py"), "exists": complete},
+            "_ok.pyd": {"path": os.path.join(path, "_ok.pyd"), "exists": complete},
+            "okFrontPanel.dll": {
+                "path": os.path.join(path, "okFrontPanel.dll"),
+                "exists": complete,
+            },
+        },
+    }
+
+
+def test_help_includes_diagnostics_commands(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "doctor" in captured.out
+    assert "reset-cache" in captured.out
+
+
+def test_doctor_success_reports_api_and_device_count(monkeypatch, tmp_path, capsys):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: path == sdk_dir)
+    monkeypatch.setattr(doctor, "frontpanel_cache_status", lambda path: _cache(path))
+    monkeypatch.setattr(
+        doctor,
+        "probe_frontpanel_import",
+        lambda path: {
+            "ok_module": FakeOk,
+            "ok_imported": True,
+            "_ok_imported": True,
+            "ok_error": None,
+            "_ok_error": None,
+            "used_cache_path": True,
+        },
+    )
+    monkeypatch.setattr(doctor, "get_frontpanel_version", lambda ok: "9.9.9")
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "FrontPanel API" in captured.out
+    assert "9.9.9" in captured.out
+    assert "Device count" in captured.out
+    assert "2" in captured.out
+
+
+def test_doctor_failure_reports_guidance(monkeypatch, tmp_path, capsys):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "missing-sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: False)
+    monkeypatch.setattr(
+        doctor, "frontpanel_cache_status", lambda path: _cache(path, complete=False)
+    )
+    monkeypatch.setattr(
+        doctor,
+        "probe_frontpanel_import",
+        lambda path: {
+            "ok_module": None,
+            "ok_imported": False,
+            "_ok_imported": False,
+            "ok_error": "ImportError: no module named ok",
+            "_ok_error": "ImportError: no module named _ok",
+            "used_cache_path": False,
+        },
+    )
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "SDK path" in captured.out
+    assert "missing" in captured.out
+    assert "mms_ok reset-cache" in captured.out
+    assert "64-bit Python" in captured.out
+
+
+def test_doctor_fails_when_frontpanel_api_probe_fails(
+    monkeypatch, tmp_path, capsys
+):
+    lib_dir = str(tmp_path / "cache")
+    sdk_dir = str(tmp_path / "sdk")
+
+    monkeypatch.setattr(doctor.os.path, "isdir", lambda path: path == sdk_dir)
+    monkeypatch.setattr(doctor, "frontpanel_cache_status", lambda path: _cache(path))
+    monkeypatch.setattr(
+        doctor,
+        "probe_frontpanel_import",
+        lambda path: {
+            "ok_module": BrokenOk,
+            "ok_imported": True,
+            "_ok_imported": True,
+            "ok_error": None,
+            "_ok_error": None,
+            "used_cache_path": True,
+        },
+    )
+    monkeypatch.setattr(doctor, "get_frontpanel_version", lambda ok: "9.9.9")
+
+    status = cli.main(["doctor", "--frontpanel-dir", sdk_dir, "--lib-dir", lib_dir])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Device count" in captured.out
+    assert "frontpanel unavailable" in captured.out
+    assert "FrontPanel API probing failed" in captured.out
+
+
+def test_reset_cache_uses_resolved_default_path(monkeypatch, capsys):
+    calls = []
+
+    def fake_reset(frontpanel_dir, lib_dir):
+        calls.append((frontpanel_dir, lib_dir))
+        return lib_dir
+
+    monkeypatch.setattr(cli, "reset_frontpanel_cache", fake_reset)
+
+    status = cli.main(["reset-cache"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert calls == [
+        (
+            cli.resolve_path(cli.DEFAULT_FRONTPANEL_DIR),
+            cli.resolve_path(cli.DEFAULT_LIB_DIR),
+        )
+    ]
+    assert cli.resolve_path(cli.DEFAULT_LIB_DIR) in captured.out
+
+
+def test_reset_cache_permission_error_reports_lock_guidance(monkeypatch, capsys):
+    def locked(frontpanel_dir, lib_dir):
+        raise PermissionError("file is locked")
+
+    monkeypatch.setattr(cli, "reset_frontpanel_cache", locked)
+
+    status = cli.main(["reset-cache"])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "file is locked" in captured.out
+    assert "IPython/Jupyter kernels" in captured.out
+    assert "ok/_ok.pyd" in captured.out

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+import mms_ok
+from mms_ok import cli
+from mms_ok import devices
+
+
+class FakeDeviceInfo:
+    def __init__(self) -> None:
+        self.serialNumber = ""
+        self.productName = ""
+        self.deviceID = ""
+        self.productID = 0
+
+
+class FakeFrontPanel:
+    attached = [
+        {
+            "serial": "SER001",
+            "model": "XEM7310-A75",
+            "device_id": "left",
+            "product_id": 101,
+        },
+        {
+            "serial": "SER002",
+            "model": "XEM7360-K160T",
+            "device_id": "right",
+            "product_id": 202,
+        },
+    ]
+
+    def __init__(self) -> None:
+        self.open = False
+        self.serial = None
+
+    def GetDeviceCount(self) -> int:
+        return len(self.attached)
+
+    def GetDeviceListSerial(self, index: int) -> str:
+        return self.attached[index]["serial"]
+
+    def GetDeviceListModel(self, index: int) -> str:
+        return self.attached[index]["model"]
+
+    def OpenBySerial(self, serial: str) -> int:
+        self.serial = serial
+        self.open = True
+        return 0
+
+    def GetDeviceInfo(self, device_info: FakeDeviceInfo) -> None:
+        match = next(item for item in self.attached if item["serial"] == self.serial)
+        device_info.serialNumber = match["serial"]
+        device_info.productName = match["model"]
+        device_info.deviceID = match["device_id"]
+        device_info.productID = match["product_id"]
+
+    def IsOpen(self) -> bool:
+        return self.open
+
+    def Close(self) -> None:
+        self.open = False
+
+
+class FakeOk:
+    okCFrontPanel = FakeFrontPanel
+    okTDeviceInfo = FakeDeviceInfo
+
+
+def test_public_list_devices_is_lazy_and_returns_device_fields(monkeypatch):
+    monkeypatch.setattr(devices, "import_ok", lambda: FakeOk)
+
+    found = mms_ok.list_devices()
+
+    assert [device.as_dict() for device in found] == [
+        {
+            "serial": "SER001",
+            "model": "XEM7310-A75",
+            "device_id": "left",
+            "product_id": 101,
+        },
+        {
+            "serial": "SER002",
+            "model": "XEM7360-K160T",
+            "device_id": "right",
+            "product_id": 202,
+        },
+    ]
+
+
+def test_list_devices_wraps_sdk_import_failure(monkeypatch):
+    def fail_import():
+        raise ImportError("no ok")
+
+    monkeypatch.setattr(devices, "import_ok", fail_import)
+
+    with pytest.raises(devices.FrontPanelUnavailableError, match="FrontPanel SDK"):
+        devices.list_devices()
+
+
+def test_devices_cli_prints_required_columns(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "list_devices",
+        lambda: [
+            devices.DeviceInfo(
+                serial="SER001",
+                model="XEM7310-A75",
+                device_id="left",
+                product_id=101,
+            )
+        ],
+    )
+
+    status = cli.main(["devices"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "device_id" in captured.out
+    assert "model" in captured.out
+    assert "serial" in captured.out
+    assert "product_id" not in captured.out
+    assert "left" in captured.out
+    assert "XEM7310-A75" in captured.out
+    assert "SER001" in captured.out
+    assert "101" not in captured.out
+
+    device_id_index = captured.out.index("device_id")
+    model_index = captured.out.index("model")
+    serial_index = captured.out.index("serial")
+    assert device_id_index < model_index < serial_index
+
+
+def test_devices_cli_reports_no_devices(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "list_devices", lambda: [])
+
+    status = cli.main(["devices"])
+
+    captured = capsys.readouterr()
+    assert status == cli.EXIT_NO_DEVICES
+    assert "No Opal Kelly FrontPanel devices found" in captured.out
+
+
+def test_devices_cli_reports_sdk_unavailable(monkeypatch, capsys):
+    def fail_list():
+        raise devices.FrontPanelUnavailableError("FrontPanel SDK is not available.")
+
+    monkeypatch.setattr(cli, "list_devices", fail_list)
+
+    status = cli.main(["devices"])
+
+    captured = capsys.readouterr()
+    assert status == cli.EXIT_SDK_UNAVAILABLE
+    assert "FrontPanel SDK is not available" in captured.out
+
+
+def test_devices_cli_reports_unexpected_discovery_error(monkeypatch, capsys):
+    def fail_list():
+        raise devices.DeviceDiscoveryError("Unexpected error while discovering devices")
+
+    monkeypatch.setattr(cli, "list_devices", fail_list)
+
+    status = cli.main(["devices"])
+
+    captured = capsys.readouterr()
+    assert status == cli.EXIT_DISCOVERY_ERROR
+    assert "Unexpected error while discovering devices" in captured.out

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import weakref
+
+import pytest
+
+from mms_ok import fpga
+from mms_ok import fpga_config
+
+
+class FakeDeviceInfo:
+    def __init__(self) -> None:
+        self.productName = "XEM7310"
+        self.serialNumber = "1234"
+        self.productID = FakeFrontPanel.brdXEM7310A75
+        self.deviceInterface = 3
+        self.usbSpeed = 3
+        self.wireWidth = 32
+        self.triggerWidth = 32
+        self.pipeWidth = 32
+
+
+class FakeFrontPanel:
+    brdXEM7310A75 = 1
+    brdXEM7310A200 = 2
+    brdXEM7360K160T = 3
+
+    instances = []
+    open_error = 0
+    configure_error = 0
+    frontpanel_enabled = True
+
+    def __init__(self) -> None:
+        self.open = False
+        self.close_calls = 0
+        self.is_open_calls = 0
+        FakeFrontPanel.instances.append(self)
+
+    @staticmethod
+    def GetAPIVersionString() -> str:
+        return "test"
+
+    def OpenBySerial(self, serial: str) -> int:
+        if FakeFrontPanel.open_error:
+            return FakeFrontPanel.open_error
+        self.open = True
+        return 0
+
+    def GetDeviceInfo(self, device_info: FakeDeviceInfo) -> None:
+        return None
+
+    def ConfigureFPGA(self, bitstream_path: str) -> int:
+        return FakeFrontPanel.configure_error
+
+    def IsFrontPanelEnabled(self) -> bool:
+        return FakeFrontPanel.frontpanel_enabled
+
+    def IsOpen(self) -> bool:
+        self.is_open_calls += 1
+        return self.open
+
+    def Close(self) -> None:
+        self.close_calls += 1
+        self.open = False
+
+
+class FakeOk:
+    OK_INTERFACE_USB3 = 3
+    okCFrontPanel = FakeFrontPanel
+    okTDeviceInfo = FakeDeviceInfo
+
+
+class LifecycleXEM(fpga.XEM):
+    check_error = None
+
+    def _check_device_settings(self) -> None:
+        if self.check_error is not None:
+            raise self.check_error
+
+    def SetLED(self, led_value: int, led_address: int = 0x00) -> None:
+        self._led_used = True
+        self._led_address = led_address
+
+
+@pytest.fixture(autouse=True)
+def fake_frontpanel(monkeypatch):
+    FakeFrontPanel.instances = []
+    FakeFrontPanel.open_error = 0
+    FakeFrontPanel.configure_error = 0
+    FakeFrontPanel.frontpanel_enabled = True
+    LifecycleXEM.check_error = None
+
+    monkeypatch.setattr(fpga, "get_ok", lambda: FakeOk)
+    monkeypatch.setattr(fpga_config, "get_ok", lambda: FakeOk)
+    monkeypatch.setattr(fpga, "print_fpga_overview", lambda **kwargs: None)
+
+
+@pytest.fixture
+def bitstream_path(tmp_path):
+    path = tmp_path / "test.bit"
+    path.write_bytes(b"fake bitstream")
+    return str(path)
+
+
+def make_uninitialized_device(handle: FakeFrontPanel) -> LifecycleXEM:
+    device = object.__new__(LifecycleXEM)
+    device.xem = handle
+    device._opened = handle.open
+    device._led_used = False
+    device._led_address = None
+    device._close_finalizer = weakref.finalize(
+        device, fpga.XEM._finalize_xem_handle, handle
+    )
+    return device
+
+
+def test_is_open_delegates_to_frontpanel_is_open():
+    handle = FakeFrontPanel()
+    handle.open = True
+    device = make_uninitialized_device(handle)
+
+    assert device.is_open() is True
+    assert handle.is_open_calls == 1
+
+    device.close()
+
+
+def test_close_calls_close_once_when_open():
+    handle = FakeFrontPanel()
+    handle.open = True
+    device = make_uninitialized_device(handle)
+
+    device.close()
+
+    assert handle.close_calls == 1
+    assert handle.open is False
+
+
+def test_close_twice_is_noop_on_second_call():
+    handle = FakeFrontPanel()
+    handle.open = True
+    device = make_uninitialized_device(handle)
+
+    device.close()
+    device.close()
+
+    assert handle.close_calls == 1
+
+
+def test_exit_uses_idempotent_close_path():
+    handle = FakeFrontPanel()
+    handle.open = True
+    device = make_uninitialized_device(handle)
+
+    device.__exit__(None, None, None)
+    device.__exit__(None, None, None)
+
+    assert handle.close_calls == 1
+
+
+def test_explicit_close_detaches_fallback_finalizer():
+    handle = FakeFrontPanel()
+    handle.open = True
+    device = make_uninitialized_device(handle)
+    finalizer = device._close_finalizer
+
+    device.close()
+    finalizer()
+
+    assert finalizer.alive is False
+    assert handle.close_calls == 1
+
+
+def test_configure_failure_after_open_closes_handle(bitstream_path):
+    FakeFrontPanel.configure_error = -1
+
+    with pytest.raises(RuntimeError):
+        LifecycleXEM(bitstream_path)
+
+    assert FakeFrontPanel.instances[0].close_calls == 1
+
+
+def test_check_device_settings_failure_after_configure_closes_handle(bitstream_path):
+    LifecycleXEM.check_error = RuntimeError("settings failed")
+
+    with pytest.raises(RuntimeError, match="settings failed"):
+        LifecycleXEM(bitstream_path)
+
+    assert FakeFrontPanel.instances[0].close_calls == 1
+
+
+def test_open_failure_does_not_close_unopened_handle(bitstream_path):
+    FakeFrontPanel.open_error = -1
+
+    with pytest.raises(ConnectionError):
+        LifecycleXEM(bitstream_path)
+
+    assert FakeFrontPanel.instances[0].close_calls == 0

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -217,7 +217,40 @@ def test_relative_bitstream_path_is_parent_bitstreams_relative(tmp_path, monkeyp
         device.close()
 
 
-def test_missing_relative_bitstream_reports_checked_parent_bitstreams_path(
+def test_absolute_bitstream_path_is_used_directly(tmp_path):
+    path = tmp_path / "design.bit"
+    path.write_bytes(b"fake bitstream")
+
+    device = LifecycleXEM(str(path))
+
+    try:
+        assert device._bitstream_path == str(path.resolve())
+    finally:
+        device.close()
+
+
+def test_filename_bitstream_ignores_cwd_file_and_uses_parent_bitstreams(
+    tmp_path, monkeypatch
+):
+    work_dir = tmp_path / "work"
+    bitstream_dir = tmp_path / "bitstreams"
+    work_dir.mkdir()
+    bitstream_dir.mkdir()
+    cwd_path = work_dir / "design.bit"
+    parent_path = bitstream_dir / "design.bit"
+    cwd_path.write_bytes(b"fake cwd bitstream")
+    parent_path.write_bytes(b"fake parent bitstream")
+    monkeypatch.chdir(work_dir)
+
+    device = LifecycleXEM("design.bit")
+
+    try:
+        assert device._bitstream_path == str(parent_path.resolve())
+    finally:
+        device.close()
+
+
+def test_missing_filename_bitstream_reports_checked_parent_bitstreams_path(
     tmp_path, monkeypatch
 ):
     work_dir = tmp_path / "work"

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -200,6 +200,39 @@ def test_open_failure_does_not_close_unopened_handle(bitstream_path):
     assert FakeFrontPanel.instances[0].close_calls == 0
 
 
+def test_relative_bitstream_path_is_parent_bitstreams_relative(tmp_path, monkeypatch):
+    work_dir = tmp_path / "work"
+    bitstream_dir = tmp_path / "bitstreams"
+    work_dir.mkdir()
+    bitstream_dir.mkdir()
+    path = bitstream_dir / "design.bit"
+    path.write_bytes(b"fake bitstream")
+    monkeypatch.chdir(work_dir)
+
+    device = LifecycleXEM("design.bit")
+
+    try:
+        assert device._bitstream_path == str(path.resolve())
+    finally:
+        device.close()
+
+
+def test_missing_relative_bitstream_reports_checked_parent_bitstreams_path(
+    tmp_path, monkeypatch
+):
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    missing = tmp_path / "bitstreams" / "missing.bit"
+    monkeypatch.chdir(work_dir)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        LifecycleXEM("missing.bit")
+
+    message = str(exc_info.value)
+    assert "../bitstreams" in message
+    assert str(missing.resolve()) in message
+
+
 def test_diagnostics_returns_required_keys(bitstream_path):
     device = LifecycleXEM(bitstream_path)
 

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -217,6 +217,26 @@ def test_relative_bitstream_path_is_parent_bitstreams_relative(tmp_path, monkeyp
         device.close()
 
 
+def test_directory_relative_bitstream_path_is_cwd_relative(tmp_path, monkeypatch):
+    work_dir = tmp_path / "work"
+    cwd_bitstream_dir = work_dir / "path" / "to"
+    parent_bitstream_dir = tmp_path / "bitstreams" / "path" / "to"
+    cwd_bitstream_dir.mkdir(parents=True)
+    parent_bitstream_dir.mkdir(parents=True)
+    cwd_path = cwd_bitstream_dir / "design.bit"
+    parent_path = parent_bitstream_dir / "design.bit"
+    cwd_path.write_bytes(b"fake cwd bitstream")
+    parent_path.write_bytes(b"fake parent bitstream")
+    monkeypatch.chdir(work_dir)
+
+    device = LifecycleXEM("path/to/design.bit")
+
+    try:
+        assert device._bitstream_path == str(cwd_path.resolve())
+    finally:
+        device.close()
+
+
 def test_absolute_bitstream_path_is_used_directly(tmp_path):
     path = tmp_path / "design.bit"
     path.write_bytes(b"fake bitstream")

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import weakref
+from io import StringIO
 
 import pytest
+from rich.console import Console
 
 from mms_ok import fpga
 from mms_ok import fpga_config
@@ -196,3 +198,36 @@ def test_open_failure_does_not_close_unopened_handle(bitstream_path):
         LifecycleXEM(bitstream_path)
 
     assert FakeFrontPanel.instances[0].close_calls == 0
+
+
+def test_diagnostics_returns_required_keys(bitstream_path):
+    device = LifecycleXEM(bitstream_path)
+
+    try:
+        data = device.diagnostics(print_output=False)
+    finally:
+        device.close()
+
+    assert data["board"]["product_name"] == "XEM7310"
+    assert data["frontpanel"]["version"] == "test"
+    assert data["frontpanel"]["is_open"] is True
+    assert data["bitstream"]["path"] == bitstream_path
+    assert data["endpoints"]["trigger"]["width"] == 32
+    assert data["endpoints"]["block_pipe"]["max_block_size"] == 16384
+
+
+def test_diagnostics_prints_rich_panel(bitstream_path):
+    device = LifecycleXEM(bitstream_path)
+    stream = StringIO()
+    console = Console(file=stream, force_terminal=False, width=120)
+
+    try:
+        data = device.diagnostics(console=console)
+    finally:
+        device.close()
+
+    output = stream.getvalue()
+    assert data["frontpanel"]["is_open"] is True
+    assert "FPGA Diagnostics" in output
+    assert "Endpoints" in output
+    assert "Bitstream path" in output


### PR DESCRIPTION
## Summary

  - Add FrontPanel SDK diagnostics with mms_ok doctor and cache refresh support via reset-cache.
  - Add Opal Kelly device discovery through mms_ok devices and the Python API mms_ok.list_devices().
  - Add an interactive setup/helper menu when running mms_ok without arguments.
  - Improve bitstream path resolution for absolute paths, ~, environment variables, relative paths, and subdirectories.
  - Make FPGA lifecycle cleanup idempotent for safer repeated close/cleanup flows.
  - Update README documentation for diagnostics, device discovery, and bitstream path behavior.
  - Add focused tests for the new diagnostics, discovery, bitstream, and lifecycle behavior.