### PR TITLE
Merge dev into master: gate unsupported platforms and restore Windows logging

### DIFF
--- a/mms_ok/__init__.py
+++ b/mms_ok/__init__.py
@@ -1,7 +1,8 @@
 """Public package interface for mms_ok.
 
-The package keeps imports lightweight: FrontPanel setup is only attempted when
-hardware-backed classes are actually accessed.
+The package fails fast on unsupported runtime platforms before importing
+FrontPanel, diagnostics, or hardware-backed modules. Runtime-heavy public names
+remain lazy after the platform gate passes.
 """
 
 try:
@@ -13,14 +14,33 @@ except ImportError:  # pragma: no cover - Python 3.7 fallback
     def _metadata_version(package_name: str) -> str:
         return get_distribution(package_name).version
 
-from .ok_setup import copy_frontpanel_files
-
-setup_frontpanel = copy_frontpanel_files
 
 try:
     __version__ = _metadata_version("mms_ok")
 except PackageNotFoundError:
     __version__ = "0+unknown"
+
+import os
+import sys
+
+from loguru import logger
+
+logger.remove()
+
+
+def _stderr_should_colorize() -> bool:
+    return os.name != "nt" and sys.stderr.isatty()
+
+
+logger.add(
+    sys.stderr,
+    format="[MMS OK] <green>{time:HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+    colorize=_stderr_should_colorize(),
+)
+
+from ._platform_gate import enforce_windows_runtime
+
+enforce_windows_runtime(logger.critical)
 
 __all__ = [
     "BIST",
@@ -32,16 +52,6 @@ __all__ = [
     "setup_frontpanel",
 ]
 
-import sys
-from loguru import logger
-
-logger.remove()
-
-logger.add(
-    sys.stderr,
-    format="[MMS OK] <green>{time:HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <level>{message}</level>",
-)
-
 
 def __getattr__(name):
     if name == "BIST":
@@ -52,10 +62,10 @@ def __getattr__(name):
         from .fpga import XEM7310, XEM7360
 
         return {"XEM7310": XEM7310, "XEM7360": XEM7360}[name]
-    if name == "copy_frontpanel_files":
+    if name in {"copy_frontpanel_files", "setup_frontpanel"}:
+        from .ok_setup import copy_frontpanel_files
+
         return copy_frontpanel_files
-    if name == "setup_frontpanel":
-        return setup_frontpanel
     if name == "list_devices":
         from .devices import list_devices
 

--- a/mms_ok/__init__.py
+++ b/mms_ok/__init__.py
@@ -20,7 +20,6 @@ try:
 except PackageNotFoundError:
     __version__ = "0+unknown"
 
-import os
 import sys
 
 from loguru import logger
@@ -29,7 +28,7 @@ logger.remove()
 
 
 def _stderr_should_colorize() -> bool:
-    return os.name != "nt" and sys.stderr.isatty()
+    return sys.stderr.isatty()
 
 
 logger.add(

--- a/mms_ok/_platform_gate.py
+++ b/mms_ok/_platform_gate.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 _UNSUPPORTED_PLATFORM_EXIT_CODE = 1
+_UNSUPPORTED_PLATFORM_SIGNAL_ENV = "MMS_OK_UNSUPPORTED_PLATFORM_SIGNAL"
 _UNSUPPORTED_PLATFORM_MESSAGE = (
     "mms_ok is a Windows-only runtime package; "
     "unsupported platform signal: os.name={!r}."
@@ -12,10 +13,12 @@ _UNSUPPORTED_PLATFORM_MESSAGE = (
 
 def enforce_windows_runtime(critical=None) -> None:
     """Terminate early when mms_ok is imported outside Windows."""
-    if os.name == "nt":
+    unsupported_signal = os.environ.get(_UNSUPPORTED_PLATFORM_SIGNAL_ENV)
+    platform_signal = unsupported_signal or os.name
+    if unsupported_signal is None and platform_signal == "nt":
         return
 
-    message = _UNSUPPORTED_PLATFORM_MESSAGE.format(os.name)
+    message = _UNSUPPORTED_PLATFORM_MESSAGE.format(platform_signal)
     if critical is None:
         print("CRITICAL | {}".format(message), file=sys.stderr)
     else:

--- a/mms_ok/_platform_gate.py
+++ b/mms_ok/_platform_gate.py
@@ -1,0 +1,23 @@
+"""Import-safe platform enforcement for mms_ok runtime entry points."""
+
+import os
+import sys
+
+_UNSUPPORTED_PLATFORM_EXIT_CODE = 1
+_UNSUPPORTED_PLATFORM_MESSAGE = (
+    "mms_ok is a Windows-only runtime package; "
+    "unsupported platform signal: os.name={!r}."
+)
+
+
+def enforce_windows_runtime(critical=None) -> None:
+    """Terminate early when mms_ok is imported outside Windows."""
+    if os.name == "nt":
+        return
+
+    message = _UNSUPPORTED_PLATFORM_MESSAGE.format(os.name)
+    if critical is None:
+        print("CRITICAL | {}".format(message), file=sys.stderr)
+    else:
+        critical(message)
+    raise SystemExit(_UNSUPPORTED_PLATFORM_EXIT_CODE)

--- a/mms_ok/diagnostics.py
+++ b/mms_ok/diagnostics.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import inspect
-from pathlib import Path
+import os
 from typing import Optional
 
 from loguru import logger
 
 
-PACKAGE_DIR = Path(__file__).resolve().parent
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def _is_package_path(filename: str) -> bool:
+    try:
+        frame_path = os.path.abspath(filename)
+        return os.path.commonpath([PACKAGE_DIR, frame_path]) == PACKAGE_DIR
+    except (OSError, ValueError):
+        return False
 
 
 def _external_caller() -> Optional[str]:
@@ -19,12 +27,12 @@ def _external_caller() -> Optional[str]:
             return f"{filename}:{frame.lineno} in {frame.function}()"
 
         try:
-            frame_path = Path(filename).resolve()
-            frame_path.relative_to(PACKAGE_DIR)
-        except ValueError:
-            return f"{frame_path}:{frame.lineno} in {frame.function}()"
+            frame_path = os.path.abspath(filename)
         except OSError:
             return f"{filename}:{frame.lineno} in {frame.function}()"
+
+        if not _is_package_path(filename):
+            return f"{frame_path}:{frame.lineno} in {frame.function}()"
     return None
 
 

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -822,7 +822,7 @@ class XEM7310(XEM):
             bitstream_path (str): Path to the bitstream file (.bit)
 
         Raises:
-            TypeError: If connected device is not a XEM7310A75/A100
+            TypeError: If connected device is not a XEM7310A75/A200
             Plus all exceptions from parent class __init__
         """
         super().__init__(bitstream_path=bitstream_path)
@@ -835,8 +835,8 @@ class XEM7310(XEM):
             ]
 
             if self.config.product_id not in target_product_id_list:
-                log_critical("Connected FPGA board is not a XEM7310A75/A100!")
-                raise TypeError("Connected FPGA board is not a XEM7310A75/A100!")
+                log_critical("Connected FPGA board is not a XEM7310A75/A200!")
+                raise TypeError("Connected FPGA board is not a XEM7310A75/A200!")
         except Exception:
             self.close()
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mms_ok"
-version = "2.1.0"
+version = "2.1.1_dev"
 description = "Python package for interfacing with Opal Kelly FPGA boards"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Test harness for package-level Windows runtime enforcement.
+
+Legacy unit tests exercise Windows runtime behavior from a Linux CI host. Load the
+local package once under a short-lived ``os.name == 'nt'`` simulation without
+routing through editable-install finders, which may use pathlib while ``os.name``
+is patched.
+"""
+
+import importlib.util
+import os
+import sys
+
+from loguru import logger as _logger  # noqa: F401  # preload before simulation
+
+
+_ORIGINAL_OS_NAME = os.name
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+_PACKAGE_DIR = os.path.join(_PROJECT_ROOT, "mms_ok")
+
+
+def _load_local_package_under_windows_simulation() -> None:
+    if "mms_ok" in sys.modules:
+        return
+
+    spec = importlib.util.spec_from_file_location(
+        "mms_ok",
+        os.path.join(_PACKAGE_DIR, "__init__.py"),
+        submodule_search_locations=[_PACKAGE_DIR],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load local mms_ok package for tests")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["mms_ok"] = module
+
+    os.name = "nt"
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop("mms_ok", None)
+        raise
+    finally:
+        os.name = _ORIGINAL_OS_NAME
+
+
+if _ORIGINAL_OS_NAME != "nt":
+    _load_local_package_under_windows_simulation()

--- a/tests/test_platform_gate.py
+++ b/tests/test_platform_gate.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _assert_platform_gate_failure(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 1
+    assert "CRITICAL" in result.stderr
+    assert "\033[" not in result.stderr
+    assert "mms_ok" in result.stderr
+    assert "Windows-only" in result.stderr
+    assert "unsupported platform" in result.stderr
+
+
+def test_non_windows_package_import_fails_fast() -> None:
+    result = _run_python("import mms_ok")
+
+    _assert_platform_gate_failure(result)
+
+
+def test_non_windows_module_execution_fails_before_menu() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "mms_ok"],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    _assert_platform_gate_failure(result)
+    assert "mms_ok setup helper" not in result.stdout
+
+
+def test_console_script_import_path_inherits_package_gate() -> None:
+    result = _run_python(
+        "from mms_ok.cli import main; raise SystemExit(main(['version']))"
+    )
+
+    _assert_platform_gate_failure(result)
+    assert "v" not in result.stdout
+
+
+def test_metadata_lookup_does_not_import_or_gate_package() -> None:
+    result = _run_python(
+        "try:\n"
+        "    import importlib.metadata as m\n"
+        "except ImportError:\n"
+        "    import importlib_metadata as m\n"
+        "print(m.version('mms_ok'))"
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip()
+    assert "CRITICAL" not in result.stderr
+    assert "Windows-only" not in result.stderr
+
+
+def test_windows_simulated_public_api_and_cli_parser_import() -> None:
+    result = _run_python(
+        "import os\n"
+        "from loguru import logger as _logger\n"
+        "original = os.name\n"
+        "os.name = 'nt'\n"
+        "try:\n"
+        "    import mms_ok\n"
+        "    expected = {'BIST', 'XEM7310', 'XEM7360', 'list_devices', "
+        "'copy_frontpanel_files', 'setup_frontpanel', '__version__'}\n"
+        "    missing = expected.difference(dir(mms_ok))\n"
+        "    import mms_ok.cli as cli\n"
+        "    parser = cli.build_parser()\n"
+        "    assert parser.prog == 'mms_ok'\n"
+        "    assert not missing, missing\n"
+        "finally:\n"
+        "    os.name = original\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_windows_simulated_import_does_not_require_colorama() -> None:
+    result = _run_python(
+        "import os\n"
+        "import sys\n"
+        "from loguru import logger as _logger\n"
+        "\n"
+        "class BlockColorama:\n"
+        "    def find_spec(self, fullname, path=None, target=None):\n"
+        "        if fullname == 'colorama' or fullname.startswith('colorama.'):\n"
+        "            raise ModuleNotFoundError(\"No module named 'colorama'\")\n"
+        "        return None\n"
+        "\n"
+        "sys.modules.pop('colorama', None)\n"
+        "sys.meta_path.insert(0, BlockColorama())\n"
+        "original = os.name\n"
+        "os.name = 'nt'\n"
+        "try:\n"
+        "    import mms_ok\n"
+        "    assert 'BIST' in dir(mms_ok)\n"
+        "finally:\n"
+        "    os.name = original\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_platform_gate_import_surface_is_safe() -> None:
+    gate_path = PROJECT_ROOT / "mms_ok" / "_platform_gate.py"
+    tree = ast.parse(gate_path.read_text())
+
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.append(node.module or "")
+
+    assert imports == ["os", "sys"]
+
+    source = gate_path.read_text()
+    forbidden = [
+        "diagnostics",
+        "loguru",
+        "ok_setup",
+        "cli",
+        "pathlib",
+        "bist",
+        "fpga",
+        "devices",
+        "FrontPanel",
+    ]
+    assert not any(name in source for name in forbidden)
+
+
+def test_console_script_mapping_remains_package_cli_main() -> None:
+    pyproject = (PROJECT_ROOT / "pyproject.toml").read_text()
+
+    assert 'mms_ok = "mms_ok.cli:main"' in pyproject
+    assert '"colorama"' not in pyproject

--- a/tests/test_platform_gate.py
+++ b/tests/test_platform_gate.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+def _run_python(code: str, env: Optional[dict] = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-c", code],
         cwd=PROJECT_ROOT,
+        env=env,
         text=True,
         capture_output=True,
         check=False,
     )
+
+
+def _run_python_as_non_windows(code: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["MMS_OK_UNSUPPORTED_PLATFORM_SIGNAL"] = "posix"
+    return _run_python(code, env=env)
 
 
 def _assert_platform_gate_failure(result: subprocess.CompletedProcess[str]) -> None:
@@ -29,18 +38,15 @@ def _assert_platform_gate_failure(result: subprocess.CompletedProcess[str]) -> N
 
 
 def test_non_windows_package_import_fails_fast() -> None:
-    result = _run_python("import mms_ok")
+    result = _run_python_as_non_windows("import mms_ok")
 
     _assert_platform_gate_failure(result)
 
 
 def test_non_windows_module_execution_fails_before_menu() -> None:
-    result = subprocess.run(
-        [sys.executable, "-m", "mms_ok"],
-        cwd=PROJECT_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
+    result = _run_python_as_non_windows(
+        "import runpy\n"
+        "runpy.run_module('mms_ok', run_name='__main__', alter_sys=True)"
     )
 
     _assert_platform_gate_failure(result)
@@ -48,7 +54,7 @@ def test_non_windows_module_execution_fails_before_menu() -> None:
 
 
 def test_console_script_import_path_inherits_package_gate() -> None:
-    result = _run_python(
+    result = _run_python_as_non_windows(
         "from mms_ok.cli import main; raise SystemExit(main(['version']))"
     )
 


### PR DESCRIPTION
 ## Summary
    - Add a Windows-only runtime platform gate so unsupported platforms fail fast with critical diagnostics.
    - Keep public package imports lazy after the platform gate to avoid loading FrontPanel/runtime-heavy modules too early.
    - Restore Windows stderr log color behavior while keeping unsupported-platform diagnostics uncolored and CI-friendly.
    - Make diagnostics path detection safer by replacing pathlib-dependent checks with os.path-based helpers.
    - Correct XEM7310A200 wording in FPGA validation errors and docs.
    - Bump the package version to 2.1.1_dev.
    - Add focused regression tests for platform gating, CLI import paths, metadata lookup, Windows-simulated imports, and   console script mapping.