### PR TITLE
Merge dev into master: add XEM autodetect and pipe-in payload logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The package is intended for researchers and lab users who already have Opal Kell
 - `XEM7360` (`XEM7360K160T`)
 
 The package also includes BIST bitstreams under `mms_ok/bitstreams` for supported board-test flows.
+`XEM(...)` can open other attached Opal Kelly boards for best-effort common
+FrontPanel API access, but unknown boards are not hardware-verified by `mms_ok`
+and do not get board-specific LED behavior or BIST support.
 
 ## What it provides
 
@@ -31,7 +34,8 @@ The package also includes BIST bitstreams under `mms_ok/bitstreams` for supporte
   - `mms_ok` supports Windows environments only.
   - **macOS and Linux are not supported.**
 - Python 3.7 or newer.
-- An Opal Kelly board supported by this package.
+- An Opal Kelly board. XEM7310/XEM7360 boards are hardware-verified by this
+  package; other Opal Kelly boards are best-effort for common FrontPanel APIs.
 - The Opal Kelly FrontPanel SDK for Windows. FrontPanel SDK `5.3.6` is recommended.
 - Python dependencies installed by `pip`: `numpy`, `bitslice`, `loguru`, `rich`, and `tqdm`.
 
@@ -82,7 +86,7 @@ mms_ok setup-frontpanel
 mms_ok check-sdk
 ```
 
-## Device discovery
+## Device discovery and autodetect
 
 List attached FrontPanel devices from the CLI:
 
@@ -106,6 +110,49 @@ for device in mms_ok.list_devices():
 `mms_ok.list_devices()` imports the FrontPanel SDK lazily, so `import mms_ok`
 does not require the SDK to be installed.
 
+Use `XEM(...)` when you want `mms_ok` to choose the concrete FPGA class
+from the connected board:
+
+```python
+from mms_ok import XEM
+
+with XEM("path/to/design.bit") as fpga:
+    print(type(fpga).__name__)
+```
+
+Autodetect behavior:
+
+- Exactly one attached XEM7310-A75/A200 opens as `XEM7310`.
+- Exactly one attached XEM7360-K160T opens as `XEM7360`.
+- Other Opal Kelly product IDs open as a generic unverified device for
+  best-effort common FrontPanel APIs.
+- Zero attached devices raises `FPGASelectionError`.
+- More than one attached device requires `serial=...` and raises
+  `FPGASelectionError` if omitted.
+- A provided `serial` must match a discovered device, otherwise
+  `FPGASelectionError` is raised.
+- If the selected device changes serial or exact product ID between discovery
+  and the constructor reopen, `ProductIDMismatchError` is raised before
+  `ConfigureFPGA` is called.
+
+`XEM` is public at the top level:
+
+```python
+from mms_ok import XEM
+```
+
+Advanced users can import facade details and the shared base class from
+`mms_ok.fpga`. For legacy compatibility, `mms_ok.fpga.XEM` remains the base
+class; the facade exposes the autodetect factory as `autodetect_xem`.
+
+```python
+from mms_ok.fpga import FPGASelectionError, ProductIDMismatchError, UnverifiedXEM, XEM, XEMBase, autodetect_xem
+```
+
+`UnverifiedXEM` is facade-visible for introspection and tests, but it is not a
+top-level public constructor promise. Prefer top-level `mms_ok.XEM(...)` for
+normal autodetect usage.
+
 ## Built-in self-test (BIST)
 
 BIST is the quickest way to confirm that the installed package, FrontPanel SDK, connected board, and packaged board-test bitstream can work together.
@@ -126,10 +173,11 @@ The package first looks for its packaged BIST bitstreams. For backward compatibi
 
 ## Bitstream paths
 
-`XEM7310(bitstream_path)` and `XEM7360(bitstream_path)` accept absolute paths,
-such as `C:\path\to\design.bit`. `~` and environment variables are expanded.
-When only a bitstream filename such as `design.bit` is provided, it is loaded
-from `../bitstreams` relative to the current working directory.
+`XEM(bitstream_path)`, `XEM7310(bitstream_path)`, and
+`XEM7360(bitstream_path)` accept absolute paths, such as
+`C:\path\to\design.bit`. `~` and environment variables are expanded. When only
+a bitstream filename such as `design.bit` is provided, it is loaded from
+`../bitstreams` relative to the current working directory.
 
 Examples:
 
@@ -159,9 +207,9 @@ A typical session is:
 
 1. Install the Windows FrontPanel SDK with the setup guide above.
 2. Install `mms_ok` and verify that it can import the FrontPanel SDK with `mms_ok check-sdk`.
-3. Connect a supported XEM board and verify visibility with `mms_ok devices`.
+3. Connect an Opal Kelly board and verify visibility with `mms_ok devices`.
 4. When appropriate, verify the board with `mms_ok bist`.
-5. Load your `.bit` file with `XEM7310` or `XEM7360`.
+5. Load your `.bit` file with `XEM`, `XEM7310`, or `XEM7360`.
 6. Use wires, triggers, pipes, and registers to control and inspect your FPGA design.
 7. Close the device when finished. Prefer a context manager in scripts.
 
@@ -170,16 +218,20 @@ A typical session is:
 Use this pattern for normal Python scripts so the device is closed automatically:
 
 ```python
-from mms_ok import XEM7310
+from mms_ok import XEM
 
 BITSTREAM = "path/to/design.bit"
 
-with XEM7310(BITSTREAM) as fpga:
+with XEM(BITSTREAM) as fpga:
     # Optional: reset the design through a wire endpoint.
     fpga.reset(reset_address=0x00, reset_time=1.0, active_low=True)
 
-    # Control board LEDs. XEM7310 exposes 8 LEDs; XEM7360 exposes 4 LEDs.
-    fpga.SetLED(0xFF)
+    # Optional board-specific LED control. Generic unverified boards raise
+    # NotImplementedError because their LED wiring is not hardware-validated.
+    try:
+        fpga.SetLED(0xFF)
+    except NotImplementedError:
+        pass
 
     # Write control words through wire-in endpoints.
     fpga.SetWireInValue(0x00, 0x12345678)
@@ -195,6 +247,50 @@ with XEM7310(BITSTREAM) as fpga:
     # Wait for a trigger-out completion flag.
     fpga.CheckTriggered(0x60, 0x01, timeout=2.0)
 ```
+
+`XEM(...)` autodetects the single attached FrontPanel device and returns
+`XEM7310`, `XEM7360`, or a generic unverified device for other Opal Kelly
+product IDs. If more than one device is attached, pass a serial number from
+`mms_ok devices` or `mms_ok.list_devices()`:
+
+```python
+from mms_ok import XEM
+
+with XEM("path/to/design.bit", serial="SERIAL123") as fpga:
+    fpga.SetWireInValue(0x00, 0x00000001)
+```
+
+The board-specific constructors also accept `serial` as a keyword-only argument
+when you want to require a verified board family and target a specific device:
+
+```python
+from mms_ok import XEM7310
+
+with XEM7310("path/to/design.bit", serial="SERIAL123") as fpga:
+    fpga.SetLED(0xFF)
+```
+
+Passing the serial positionally is intentionally not supported; use
+`serial="..."`.
+
+You can still use strict verified constructors directly when you want to require
+a specific board family. These constructors reject the wrong connected product
+before configuring the FPGA:
+
+```python
+from mms_ok import XEM7310, XEM7360
+
+with XEM7310("path/to/design.bit") as fpga:
+    fpga.SetLED(0xFF)
+
+with XEM7360("path/to/design.bit") as fpga:
+    fpga.SetLED(0x0F)
+```
+
+Generic unverified boards returned by `XEM(...)` emit a runtime warning.
+They inherit common wires, triggers, pipes, block pipes, registers, reset, and
+lifecycle methods, but board-specific helpers such as `SetLED(...)` are not
+supported and BIST remains limited to the verified boards listed above.
 
 ### Notebook or interactive usage
 
@@ -393,14 +489,24 @@ FrontPanel endpoint ranges used by the helpers follow the standard Opal Kelly la
 Import the public classes from `mms_ok`:
 
 ```python
-from mms_ok import BIST, XEM7310, XEM7360, list_devices
+from mms_ok import BIST, XEM, XEM7310, XEM7360, list_devices
 ```
 
-Common methods on `XEM7310` and `XEM7360` include:
+Facade-only FPGA helpers and the shared base class are available from
+`mms_ok.fpga`. For compatibility, `mms_ok.fpga.XEM` is the shared base class;
+use top-level `mms_ok.XEM(...)` or facade `autodetect_xem(...)` for
+autodetect construction:
 
-- Discovery: `list_devices()`.
+```python
+from mms_ok.fpga import FPGASelectionError, ProductIDMismatchError, UnverifiedXEM, XEM, XEMBase, autodetect_xem
+```
+
+Common methods on `XEM7310`, `XEM7360`, and generic devices returned by
+`XEM(...)` include:
+
+- Discovery: `list_devices()`, `XEM(...)`.
 - Device lifecycle: `close()`, context manager support, `reset(...)`.
-- LEDs: `SetLED(...)`.
+- LEDs: `SetLED(...)` on verified XEM7310/XEM7360 only.
 - Wires: `SetWireInValue(...)`, `UpdateWireIns()`, `UpdateWireOuts()`, `GetWireOutValue(...)`.
 - Triggers: `ActivateTriggerIn(...)`, `UpdateTriggerOuts()`, `IsTriggered(...)`, `CheckTriggered(...)`.
 - Pipes: `WriteToPipeIn(...)`, `ReadFromPipeOut(...)`, `WriteToBlockPipeIn(...)`, `ReadFromBlockPipeOut(...)`.

--- a/README.md
+++ b/README.md
@@ -385,6 +385,35 @@ For write calls, each supported input type is prepared differently:
 | NumPy integer array | Flattened in C order, then each element is encoded using `endian`, independent of the array dtype byte order. |
 | NumPy non-integer array | Flattened in C order and sent as contiguous raw bytes. |
 
+#### Verbose pipe-in logging
+
+Pass `verbose=True` to pipe-in write helpers when you need to inspect the exact
+FPGA-cycle payload sent to the endpoint. The verbose log prints the prepared
+payload as uppercase hexadecimal chunks after `endian` and `reverse` have been
+applied, so it is useful for matching software writes against HDL waveforms.
+
+```python
+payload = "AABBCCDD11223344556677889900A1B2"
+
+# Logs four 32-bit FPGA payload cycles for a normal pipe-in transfer.
+fpga.WriteToPipeIn(0x80, payload, verbose=True)
+```
+
+For normal `WriteToPipeIn` calls, verbose logging uses 32-bit cycle chunks.
+`WriteToBlockPipeIn` supports the same option and also includes the selected
+`block_size` in the summary log. Block pipe verbose chunks follow the transport
+formatting policy: USB 2 block pipes log 16-bit FPGA payload cycles, while USB
+3, PCIe, and the default policy log 32-bit cycles.
+
+```python
+# Logs the selected block_size plus per-cycle FPGA payload chunks.
+fpga.WriteToBlockPipeIn(0x80, payload, block_size=16, verbose=True)
+```
+
+`verbose=True` only adds debug logging; it does not change the bytes sent or the
+return value. The device-wide `set_verbose_level(...)` option remains separate
+and logs high-level method summaries such as the byte count written.
+
 #### `endian` and `reverse`
 
 `endian` controls byte order inside each formatted word. For normal pipes, hex

--- a/mms_ok/__init__.py
+++ b/mms_ok/__init__.py
@@ -8,16 +8,30 @@ remain lazy after the platform gate passes.
 try:
     from importlib.metadata import PackageNotFoundError, version as _metadata_version
 except ImportError:  # pragma: no cover - Python 3.7 fallback
-    from pkg_resources import DistributionNotFound as PackageNotFoundError
-    from pkg_resources import get_distribution
+    try:
+        from importlib_metadata import (  # type: ignore
+            PackageNotFoundError,
+            version as _metadata_version,
+        )
+    except ImportError:  # pragma: no cover - last-resort legacy fallback
+        try:
+            from pkg_resources import DistributionNotFound as PackageNotFoundError
+            from pkg_resources import get_distribution
 
-    def _metadata_version(package_name: str) -> str:
-        return get_distribution(package_name).version
+            def _metadata_version(package_name: str) -> str:
+                return get_distribution(package_name).version
+
+        except Exception:  # pragma: no cover - minimal import-safe fallback
+            class PackageNotFoundError(Exception):
+                pass
+
+            def _metadata_version(package_name: str) -> str:
+                raise PackageNotFoundError(package_name)
 
 
 try:
     __version__ = _metadata_version("mms_ok")
-except PackageNotFoundError:
+except Exception:
     __version__ = "0+unknown"
 
 import sys
@@ -43,6 +57,7 @@ enforce_windows_runtime(logger.critical)
 
 __all__ = [
     "BIST",
+    "XEM",
     "XEM7310",
     "XEM7360",
     "__version__",
@@ -57,6 +72,10 @@ def __getattr__(name):
         from .bist import BIST
 
         return BIST
+    if name == "XEM":
+        from .fpga_factory import XEM
+
+        return XEM
     if name in {"XEM7310", "XEM7360"}:
         from .fpga import XEM7310, XEM7360
 

--- a/mms_ok/fpga.py
+++ b/mms_ok/fpga.py
@@ -7,8 +7,21 @@ legacy imports such as ``from mms_ok.fpga import XEM7310`` and
 
 from __future__ import annotations
 
-from .fpga_base import XEM
+from .fpga_base import ProductIDMismatchError, XEM
+from .fpga_factory import FPGASelectionError, XEM as autodetect_xem
+from .fpga_generic import UnverifiedXEM
 from .fpga_xem7310 import XEM7310
 from .fpga_xem7360 import XEM7360
 
-__all__ = ["XEM", "XEM7310", "XEM7360"]
+XEMBase = XEM
+
+__all__ = [
+    "FPGASelectionError",
+    "ProductIDMismatchError",
+    "UnverifiedXEM",
+    "XEM",
+    "XEMBase",
+    "autodetect_xem",
+    "XEM7310",
+    "XEM7360",
+]

--- a/mms_ok/fpga_base.py
+++ b/mms_ok/fpga_base.py
@@ -20,6 +20,7 @@ from . import __version__
 from .bitstreams import format_checked_paths, resolve_user_bitstream_path
 from .diagnostics import log_critical, log_error
 from .display import print_fpga_overview
+from .devices import _to_text
 from .fpga_components import (
     BlockPipeOperations,
     PipeOperations,
@@ -268,7 +269,7 @@ class XEM(ABC):
         the reopen safe: serial or exact product-id drift fails before class
         validation or FPGA configuration can occur.
         """
-        actual_serial = str(self.config.serial_number)
+        actual_serial = _to_text(self.config.serial_number)
         if self._serial and actual_serial != self._serial:
             message = (
                 "Selected FrontPanel device serial changed before configuration: "

--- a/mms_ok/fpga_base.py
+++ b/mms_ok/fpga_base.py
@@ -691,6 +691,7 @@ class XEM(ABC):
         reorder_str: Optional[bool] = None,
         *,
         reverse: bool = False,
+        verbose: bool = False,
     ) -> int:
         """
         Write data to a pipe-in endpoint.
@@ -703,6 +704,7 @@ class XEM(ABC):
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
+            verbose (bool): If True, log the prepared payload bytes as uppercase hex
 
         Returns:
             int: Number of bytes written
@@ -711,7 +713,12 @@ class XEM(ABC):
             ValueError: If data format is invalid
         """
         written = self.pipe_ops.write_to_pipe_in(
-            ep_addr, data, endian, reorder_str=reorder_str, reverse=reverse
+            ep_addr,
+            data,
+            endian,
+            reorder_str=reorder_str,
+            reverse=reverse,
+            verbose=verbose,
         )
         if self.verbose_level > 0:
             logger.debug(
@@ -765,6 +772,7 @@ class XEM(ABC):
         reorder_str: Optional[bool] = None,
         *,
         reverse: bool = False,
+        verbose: bool = False,
     ) -> int:
         """
         Write data to a block pipe-in endpoint.
@@ -779,6 +787,7 @@ class XEM(ABC):
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
+            verbose (bool): If True, log the prepared payload bytes as uppercase hex
 
         Returns:
             int: Number of bytes written
@@ -793,6 +802,7 @@ class XEM(ABC):
             endian=endian,
             reorder_str=reorder_str,
             reverse=reverse,
+            verbose=verbose,
         )
         if self.verbose_level > 0:
             logger.debug(

--- a/mms_ok/fpga_base.py
+++ b/mms_ok/fpga_base.py
@@ -704,7 +704,7 @@ class XEM(ABC):
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
-            verbose (bool): If True, log the prepared payload bytes as uppercase hex
+            verbose (bool): If True, log payload as per-cycle uppercase hex chunks
 
         Returns:
             int: Number of bytes written
@@ -787,7 +787,7 @@ class XEM(ABC):
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
-            verbose (bool): If True, log the prepared payload bytes as uppercase hex
+            verbose (bool): If True, log payload as per-cycle uppercase hex chunks
 
         Returns:
             int: Number of bytes written

--- a/mms_ok/fpga_base.py
+++ b/mms_ok/fpga_base.py
@@ -36,6 +36,10 @@ from .validation import validate_address, validate_wire_value
 _FRONTPANEL_ERROR_CODE_RE = re.compile(r"\bError\s+(-?\d+)\b")
 
 
+class ProductIDMismatchError(RuntimeError):
+    """Raised when a selected device changes identity before configuration."""
+
+
 class XEM(ABC):
     """
     Abstract base class for Opal Kelly FPGA devices.
@@ -58,7 +62,13 @@ class XEM(ABC):
         ...     fpga.reset()        # Reset the device
     """
 
-    def __init__(self, bitstream_path: str) -> None:
+    def __init__(
+        self,
+        bitstream_path: str,
+        *,
+        serial: Optional[str] = None,
+        _expected_product_id: Optional[int] = None,
+    ) -> None:
         """
         Initialize and configure the FPGA device.
 
@@ -78,6 +88,8 @@ class XEM(ABC):
         self._led_address = None
         self._opened = False
         self._close_finalizer = None
+        self._serial = "" if serial is None else str(serial)
+        self._expected_product_id = _expected_product_id
         ok = get_ok()
         self.xem = ok.okCFrontPanel()
         self._close_finalizer = weakref.finalize(
@@ -92,7 +104,9 @@ class XEM(ABC):
             self._validate_bitstream_path()
 
             self._connect()
+            self._validate_expected_product_id_before_configure()
             self._validate_connected_board()
+            self._before_configure()
             self._configure()
 
             self.auto_wire_in = True
@@ -226,9 +240,17 @@ class XEM(ABC):
         """
         ok = get_ok()
 
-        if self.xem.OpenBySerial(""):
-            log_critical("Device is not opened!")
-            raise ConnectionError("Device is not opened!")
+        error_code = self.xem.OpenBySerial(self._serial)
+        if error_code:
+            if self._serial:
+                message = (
+                    "Device with serial {!r} is not opened! "
+                    "(OpenBySerial returned {})".format(self._serial, error_code)
+                )
+            else:
+                message = "Device is not opened!"
+            log_critical(message)
+            raise ConnectionError(message)
         self._opened = True
 
         device_info = ok.okTDeviceInfo()
@@ -237,6 +259,43 @@ class XEM(ABC):
         self.config = FPGAConfig.from_device_info(device_info)
         self.config.validate()
 
+    def _validate_expected_product_id_before_configure(self) -> None:
+        """
+        Verify factory discovery identity after opening the selected serial.
+
+        The autodetect factory discovers a serial/product-id pair, then reopens
+        that serial through the normal constructor lifecycle. This guard makes
+        the reopen safe: serial or exact product-id drift fails before class
+        validation or FPGA configuration can occur.
+        """
+        actual_serial = str(self.config.serial_number)
+        if self._serial and actual_serial != self._serial:
+            message = (
+                "Selected FrontPanel device serial changed before configuration: "
+                "expected serial={!r}, opened serial={!r}, opened product_id={}. "
+                "Retry discovery and pass an explicit serial if needed."
+            ).format(self._serial, actual_serial, self.config.product_id)
+            log_critical(message)
+            raise ProductIDMismatchError(message)
+
+        expected_product_id = self._expected_product_id
+        if expected_product_id is None:
+            return
+
+        actual_product_id = int(self.config.product_id)
+        if actual_product_id != int(expected_product_id):
+            message = (
+                "Selected FrontPanel device changed before configuration: "
+                "serial={!r}, expected product_id={}, opened product_id={}. "
+                "Retry discovery and pass an explicit serial if needed."
+            ).format(
+                self._serial or self.config.serial_number,
+                expected_product_id,
+                actual_product_id,
+            )
+            log_critical(message)
+            raise ProductIDMismatchError(message)
+
     def _validate_connected_board(self) -> None:
         """
         Validate that the connected board matches the concrete device class.
@@ -244,6 +303,10 @@ class XEM(ABC):
         Base devices accept any connected board. Board-specific subclasses can
         override this hook to fail before configuring an incompatible FPGA.
         """
+        pass
+
+    def _before_configure(self) -> None:
+        """Run subclass hooks after board validation but before ConfigureFPGA."""
         pass
 
     def _configure(self) -> None:

--- a/mms_ok/fpga_components.py
+++ b/mms_ok/fpga_components.py
@@ -75,6 +75,7 @@ def _log_pipe_in_payload_cycles(
     ep_addr: int,
     payload: bytearray,
     cycle_byte_width: int,
+    endian: str,
     *,
     block_size: Optional[int] = None,
 ) -> None:
@@ -82,7 +83,7 @@ def _log_pipe_in_payload_cycles(
     block_text = "" if block_size is None else f" | block_size={block_size}"
     cycle_count = (len(payload) + cycle_byte_width - 1) // cycle_byte_width
     logger.debug(
-        "{} >> Addr {}{} | Payload: {} bytes, {}-bit/cycle, {} cycles",
+        "{} >> Addr {}{} | FPGA payload: {} bytes, {}-bit/cycle, {} cycles",
         operation,
         hex(ep_addr),
         block_text,
@@ -91,15 +92,17 @@ def _log_pipe_in_payload_cycles(
         cycle_count,
     )
     for cycle, offset, chunk in _iter_payload_cycles(payload, cycle_byte_width):
+        fpga_payload = int.from_bytes(chunk, byteorder=endian)
         logger.debug(
-            "{} >> Addr {} | cycle {} | byte[{}:{}] | {}-bit payload: {}",
+            "{} >> Addr {} | cycle {} | byte[{}:{}] | FPGA {}-bit payload: {:0{}X}",
             operation,
             hex(ep_addr),
             cycle,
             offset,
             offset + len(chunk),
             width_bits,
-            chunk.hex().upper(),
+            fpga_payload,
+            len(chunk) * 2,
         )
 
 
@@ -513,6 +516,7 @@ class PipeOperations:
                 ep_addr,
                 prepared_data,
                 4,
+                endian,
             )
         return result
 
@@ -672,6 +676,7 @@ class BlockPipeOperations:
                 ep_addr,
                 prepared_data,
                 self._word_byte_width(),
+                endian,
                 block_size=block_size,
             )
         return result

--- a/mms_ok/fpga_components.py
+++ b/mms_ok/fpga_components.py
@@ -63,6 +63,46 @@ def _format_hex_for_bit_width(value: int, bit_width: int) -> str:
     return f"0x{value:0{display_width}_X}"
 
 
+def _iter_payload_cycles(payload: bytearray, cycle_byte_width: int):
+    if cycle_byte_width <= 0:
+        raise ValueError("cycle_byte_width must be positive")
+    for cycle, offset in enumerate(range(0, len(payload), cycle_byte_width)):
+        yield cycle, offset, payload[offset : offset + cycle_byte_width]
+
+
+def _log_pipe_in_payload_cycles(
+    operation: str,
+    ep_addr: int,
+    payload: bytearray,
+    cycle_byte_width: int,
+    *,
+    block_size: Optional[int] = None,
+) -> None:
+    width_bits = cycle_byte_width * 8
+    block_text = "" if block_size is None else f" | block_size={block_size}"
+    cycle_count = (len(payload) + cycle_byte_width - 1) // cycle_byte_width
+    logger.debug(
+        "{} >> Addr {}{} | Payload: {} bytes, {}-bit/cycle, {} cycles",
+        operation,
+        hex(ep_addr),
+        block_text,
+        len(payload),
+        width_bits,
+        cycle_count,
+    )
+    for cycle, offset, chunk in _iter_payload_cycles(payload, cycle_byte_width):
+        logger.debug(
+            "{} >> Addr {} | cycle {} | byte[{}:{}] | {}-bit payload: {}",
+            operation,
+            hex(ep_addr),
+            cycle,
+            offset,
+            offset + len(chunk),
+            width_bits,
+            chunk.hex().upper(),
+        )
+
+
 def _check_error_code(error_code: int, operation: str, failure_message: str) -> int:
     if error_code < 0:
         ok = get_ok()
@@ -450,7 +490,7 @@ class PipeOperations:
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
-            verbose (bool): If True, log the prepared payload bytes as uppercase hex
+            verbose (bool): If True, log payload as per-cycle uppercase hex chunks
 
         Returns:
             int: Error code (0 on success)
@@ -468,11 +508,11 @@ class PipeOperations:
             error_code, "WriteToPipeIn", "Failed to write to pipe-in"
         )
         if verbose:
-            logger.debug(
-                "WriteToPipeIn >> Addr {} | Payload ({} bytes): {}",
-                hex(ep_addr),
-                len(prepared_data),
-                prepared_data.hex().upper(),
+            _log_pipe_in_payload_cycles(
+                "WriteToPipeIn",
+                ep_addr,
+                prepared_data,
+                4,
             )
         return result
 
@@ -604,7 +644,7 @@ class BlockPipeOperations:
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
-            verbose (bool): If True, log the prepared payload bytes as uppercase hex
+            verbose (bool): If True, log payload as per-cycle uppercase hex chunks
 
         Returns:
             int: Error code (0 on success)
@@ -627,13 +667,12 @@ class BlockPipeOperations:
             error_code, "WriteToBlockPipeIn", "Failed to write to block pipe-in"
         )
         if verbose:
-            logger.debug(
-                "WriteToBlockPipeIn >> Addr {} | block_size={} | "
-                "Payload ({} bytes): {}",
-                hex(ep_addr),
-                block_size,
-                len(prepared_data),
-                prepared_data.hex().upper(),
+            _log_pipe_in_payload_cycles(
+                "WriteToBlockPipeIn",
+                ep_addr,
+                prepared_data,
+                self._word_byte_width(),
+                block_size=block_size,
             )
         return result
 

--- a/mms_ok/fpga_components.py
+++ b/mms_ok/fpga_components.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional, Union
 
 import numpy as np
+from loguru import logger
 
 from .address import (
     BLOCK_PIPE_IN_END,
@@ -438,6 +439,7 @@ class PipeOperations:
         reorder_str: Optional[bool] = None,
         *,
         reverse: bool = False,
+        verbose: bool = False,
     ) -> int:
         """
         Write data to a pipe-in endpoint.
@@ -448,6 +450,7 @@ class PipeOperations:
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
+            verbose (bool): If True, log the prepared payload bytes as uppercase hex
 
         Returns:
             int: Error code (0 on success)
@@ -461,9 +464,17 @@ class PipeOperations:
         prepared_data = self._prepare_data(data, endian, reverse=reverse)
 
         error_code = self.xem.WriteToPipeIn(ep_addr, prepared_data)
-        return _check_error_code(
+        result = _check_error_code(
             error_code, "WriteToPipeIn", "Failed to write to pipe-in"
         )
+        if verbose:
+            logger.debug(
+                "WriteToPipeIn >> Addr {} | Payload ({} bytes): {}",
+                hex(ep_addr),
+                len(prepared_data),
+                prepared_data.hex().upper(),
+            )
+        return result
 
     def read_from_pipe_out(
         self,
@@ -581,6 +592,7 @@ class BlockPipeOperations:
         reorder_str: Optional[bool] = None,
         *,
         reverse: bool = False,
+        verbose: bool = False,
     ) -> int:
         """
         Write data to a block pipe-in endpoint.
@@ -592,6 +604,7 @@ class BlockPipeOperations:
             endian (str): Byte order used for string and integer numpy array data
             reorder_str (bool): Deprecated; use endian instead
             reverse (bool): If True, transfer supported inputs from latest element/word first
+            verbose (bool): If True, log the prepared payload bytes as uppercase hex
 
         Returns:
             int: Error code (0 on success)
@@ -610,9 +623,19 @@ class BlockPipeOperations:
             self._transport_policy.validate_block_size(block_size, len(prepared_data))
 
         error_code = self.xem.WriteToBlockPipeIn(ep_addr, block_size, prepared_data)
-        return _check_error_code(
+        result = _check_error_code(
             error_code, "WriteToBlockPipeIn", "Failed to write to block pipe-in"
         )
+        if verbose:
+            logger.debug(
+                "WriteToBlockPipeIn >> Addr {} | block_size={} | "
+                "Payload ({} bytes): {}",
+                hex(ep_addr),
+                block_size,
+                len(prepared_data),
+                prepared_data.hex().upper(),
+            )
+        return result
 
     def read_from_block_pipe_out(
         self,

--- a/mms_ok/fpga_factory.py
+++ b/mms_ok/fpga_factory.py
@@ -1,0 +1,69 @@
+"""Discovery-backed FPGA factory."""
+
+from __future__ import annotations
+
+from typing import Optional, Type
+
+from .devices import DeviceInfo, list_devices
+from .fpga_base import XEM as XEMBase
+from .fpga_generic import UnverifiedXEM
+from .fpga_products import xem7310_product_ids, xem7360_product_ids
+from .fpga_xem7310 import XEM7310
+from .fpga_xem7360 import XEM7360
+
+
+class FPGASelectionError(RuntimeError):
+    """Raised when autodetect cannot select exactly one FrontPanel device."""
+
+
+def _device_summary(device: DeviceInfo) -> str:
+    return (
+        "serial={serial!r}, model={model!r}, device_id={device_id!r}, "
+        "product_id={product_id}"
+    ).format(**device.as_dict())
+
+
+def _select_device(serial: Optional[str]) -> DeviceInfo:
+    devices = list_devices()
+
+    if serial is not None:
+        serial_text = str(serial)
+        for device in devices:
+            if device.serial == serial_text:
+                return device
+        available = "; ".join(_device_summary(device) for device in devices) or "none"
+        raise FPGASelectionError(
+            "No Opal Kelly FrontPanel device with serial {!r} was found. "
+            "Available devices: {}".format(serial_text, available)
+        )
+
+    if not devices:
+        raise FPGASelectionError("No Opal Kelly FrontPanel devices were found.")
+
+    if len(devices) > 1:
+        available = "; ".join(_device_summary(device) for device in devices)
+        raise FPGASelectionError(
+            "Multiple Opal Kelly FrontPanel devices were found; pass serial=... "
+            "to XEM. Available devices: {}".format(available)
+        )
+
+    return devices[0]
+
+
+def _class_for_product_id(product_id: int) -> Type[XEMBase]:
+    if int(product_id) in xem7310_product_ids():
+        return XEM7310
+    if int(product_id) in xem7360_product_ids():
+        return XEM7360
+    return UnverifiedXEM
+
+
+def XEM(bitstream_path: str, serial: Optional[str] = None) -> XEMBase:
+    """Open a discovered Opal Kelly FPGA as the best matching mms_ok class."""
+    device = _select_device(serial)
+    device_class = _class_for_product_id(device.product_id)
+    return device_class(
+        bitstream_path,
+        serial=device.serial,
+        _expected_product_id=device.product_id,
+    )

--- a/mms_ok/fpga_generic.py
+++ b/mms_ok/fpga_generic.py
@@ -1,0 +1,54 @@
+"""Generic best-effort FrontPanel access for unverified Opal Kelly boards."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Optional
+
+from .diagnostics import log_critical
+from .fpga_base import XEM
+from .fpga_products import verified_product_ids
+
+
+class UnverifiedXEM(XEM):
+    """Concrete generic XEM for unverified boards and common FrontPanel APIs."""
+
+    def __init__(
+        self,
+        bitstream_path: str,
+        *,
+        serial: Optional[str] = None,
+        _expected_product_id: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            bitstream_path,
+            serial=serial,
+            _expected_product_id=_expected_product_id,
+        )
+
+    def _validate_connected_board(self) -> None:
+        if int(self.config.product_id) in verified_product_ids():
+            message = (
+                "UnverifiedXEM cannot be used for known verified mms_ok boards; "
+                "use XEM, XEM7310, or XEM7360 instead."
+            )
+            log_critical(message)
+            raise TypeError(message)
+
+    def _check_device_settings(self) -> None:
+        """No board-specific settings are known for unverified hardware."""
+        pass
+
+    def _before_configure(self) -> None:
+        warnings.warn(
+            "Connected Opal Kelly board is unverified and not hardware-validated "
+            "by mms_ok; only common FrontPanel APIs are best-effort supported.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+    def SetLED(self, led_value: int, led_address: int = 0x00) -> None:
+        raise NotImplementedError(
+            "SetLED is unsupported for unverified Opal Kelly boards because "
+            "mms_ok has not hardware-validated board-specific LED wiring."
+        )

--- a/mms_ok/fpga_products.py
+++ b/mms_ok/fpga_products.py
@@ -1,0 +1,38 @@
+"""Private FrontPanel product-id helpers for supported board families."""
+
+from __future__ import annotations
+
+from typing import Set
+
+from .ok_setup import get_ok
+
+XEM7310_PRODUCT_ID_NAMES = ("brdXEM7310A75", "brdXEM7310A200")
+XEM7360_PRODUCT_ID_NAMES = ("brdXEM7360K160T",)
+VERIFIED_PRODUCT_ID_NAMES = XEM7310_PRODUCT_ID_NAMES + XEM7360_PRODUCT_ID_NAMES
+
+
+def _product_ids(names, ok_module=None) -> Set[int]:
+    frontpanel = (ok_module or get_ok()).okCFrontPanel
+    missing = [name for name in names if not hasattr(frontpanel, name)]
+    if missing:
+        raise AttributeError(
+            "FrontPanel SDK is missing required product-id constants: {}".format(
+                ", ".join(missing)
+            )
+        )
+    return {int(getattr(frontpanel, name)) for name in names}
+
+
+def xem7310_product_ids(ok_module=None) -> Set[int]:
+    """Return FrontPanel product IDs for verified XEM7310 variants."""
+    return _product_ids(XEM7310_PRODUCT_ID_NAMES, ok_module)
+
+
+def xem7360_product_ids(ok_module=None) -> Set[int]:
+    """Return FrontPanel product IDs for verified XEM7360 variants."""
+    return _product_ids(XEM7360_PRODUCT_ID_NAMES, ok_module)
+
+
+def verified_product_ids(ok_module=None) -> Set[int]:
+    """Return all product IDs with hardware-verified board classes."""
+    return _product_ids(VERIFIED_PRODUCT_ID_NAMES, ok_module)

--- a/mms_ok/fpga_xem7310.py
+++ b/mms_ok/fpga_xem7310.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from .diagnostics import log_critical
 from .fpga_base import XEM
-from .ok_setup import get_ok
+from .fpga_products import xem7310_product_ids
 from .validation import validate_address, validate_wire_value
 
 
@@ -23,7 +23,9 @@ class XEM7310(XEM):
         >>> fpga = XEM7310("bitstream.bit")
     """
 
-    def __init__(self, bitstream_path: str) -> None:
+    def __init__(
+        self, bitstream_path: str, *, serial=None, _expected_product_id=None
+    ) -> None:
         """
         Initialize XEM7310 FPGA device.
 
@@ -34,17 +36,14 @@ class XEM7310(XEM):
             TypeError: If connected device is not a XEM7310A75/A200
             Plus all exceptions from parent class __init__
         """
-        super().__init__(bitstream_path=bitstream_path)
+        super().__init__(
+            bitstream_path=bitstream_path,
+            serial=serial,
+            _expected_product_id=_expected_product_id,
+        )
 
     def _validate_connected_board(self) -> None:
-        ok = get_ok()
-
-        target_product_id_list = [
-            ok.okCFrontPanel.brdXEM7310A75,
-            ok.okCFrontPanel.brdXEM7310A200,
-        ]
-
-        if self.config.product_id not in target_product_id_list:
+        if int(self.config.product_id) not in xem7310_product_ids():
             log_critical("Connected FPGA board is not a XEM7310A75/A200!")
             raise TypeError("Connected FPGA board is not a XEM7310A75/A200!")
 

--- a/mms_ok/fpga_xem7360.py
+++ b/mms_ok/fpga_xem7360.py
@@ -5,6 +5,7 @@ from loguru import logger
 
 from .diagnostics import log_critical
 from .fpga_base import XEM
+from .fpga_products import xem7360_product_ids
 from .ok_setup import get_ok
 from .validation import validate_address, validate_wire_value
 
@@ -23,7 +24,9 @@ class XEM7360(XEM):
         >>> fpga = XEM7360("bitstream.bit")
     """
 
-    def __init__(self, bitstream_path: str) -> None:
+    def __init__(
+        self, bitstream_path: str, *, serial=None, _expected_product_id=None
+    ) -> None:
         """
         Initialize XEM7360 FPGA device.
 
@@ -34,14 +37,14 @@ class XEM7360(XEM):
             TypeError: If connected device is not a XEM7360K160T
             Plus all exceptions from parent class __init__
         """
-        super().__init__(bitstream_path=bitstream_path)
+        super().__init__(
+            bitstream_path=bitstream_path,
+            serial=serial,
+            _expected_product_id=_expected_product_id,
+        )
 
     def _validate_connected_board(self) -> None:
-        ok = get_ok()
-
-        target_product_id = ok.okCFrontPanel.brdXEM7360K160T
-
-        if self.config.product_id != target_product_id:
+        if int(self.config.product_id) not in xem7360_product_ids():
             log_critical("Connected FPGA board is not a XEM7360K160T!")
             raise TypeError("Connected FPGA board is not a XEM7360K160T!")
 

--- a/tests/test_bitstreams.py
+++ b/tests/test_bitstreams.py
@@ -160,6 +160,15 @@ def test_bist_resolver_prefers_packaged_bitstream(monkeypatch, tmp_path):
     )
 
 
+def test_bist_bitstreams_remain_verified_board_only():
+    assert set(bist.BIST_BITSTREAMS) == {
+        "XEM7310-A75",
+        "XEM7310-A200",
+        "XEM7360-K160T",
+    }
+    assert not any("unknown" in key.lower() for key in bist.BIST_BITSTREAMS)
+
+
 def test_bist_resolver_falls_back_to_legacy_bitstream(monkeypatch, tmp_path):
     package_dir = tmp_path / "package"
     legacy_dir = tmp_path / "legacy"

--- a/tests/test_fpga_lifecycle.py
+++ b/tests/test_fpga_lifecycle.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from mms_ok import fpga
 from mms_ok import fpga_base
 from mms_ok import fpga_config
-from mms_ok import fpga_xem7310
+from mms_ok import fpga_products
 from mms_ok import fpga_xem7360
 
 
@@ -99,7 +99,7 @@ class FakeOk:
     okCDeviceSettings = FakeDeviceSettings
 
 
-class LifecycleXEM(fpga.XEM):
+class LifecycleXEM(fpga_base.XEM):
     check_error = None
 
     def _check_device_settings(self) -> None:
@@ -123,6 +123,7 @@ def fake_frontpanel(monkeypatch):
 
     monkeypatch.setattr(fpga_base, "get_ok", lambda: FakeOk)
     monkeypatch.setattr(fpga_config, "get_ok", lambda: FakeOk)
+    monkeypatch.setattr(fpga_products, "get_ok", lambda: FakeOk)
     monkeypatch.setattr(fpga_base, "print_fpga_overview", lambda **kwargs: None)
 
 
@@ -140,7 +141,7 @@ def make_uninitialized_device(handle: FakeFrontPanel) -> LifecycleXEM:
     device._led_used = False
     device._led_address = None
     device._close_finalizer = weakref.finalize(
-        device, fpga.XEM._finalize_xem_handle, handle
+        device, fpga_base.XEM._finalize_xem_handle, handle
     )
     return device
 
@@ -242,13 +243,11 @@ def test_explicit_close_detaches_fallback_finalizer():
     assert handle.close_calls == 1
 
 
-def test_xem7310_constructor_uses_board_module_get_ok(monkeypatch, bitstream_path):
-    monkeypatch.setattr(fpga_xem7310, "get_ok", lambda: FakeOk)
-
+def test_xem7310_constructor_uses_product_id_registry(bitstream_path):
     device = fpga.XEM7310(bitstream_path)
 
     try:
-        assert isinstance(device, fpga.XEM)
+        assert isinstance(device, fpga_base.XEM)
         assert device.config.product_id == FakeFrontPanel.brdXEM7310A75
         assert device.is_open() is True
         assert FakeFrontPanel.instances[0].configure_calls == [bitstream_path]
@@ -264,7 +263,7 @@ def test_xem7360_constructor_uses_board_module_get_ok(monkeypatch, bitstream_pat
     device = fpga.XEM7360(bitstream_path)
 
     try:
-        assert isinstance(device, fpga.XEM)
+        assert isinstance(device, fpga_base.XEM)
         assert device.config.product_id == FakeFrontPanel.brdXEM7360K160T
         assert device._vadj_voltage_dict == {
             "vadj1": 1.2,
@@ -277,10 +276,9 @@ def test_xem7360_constructor_uses_board_module_get_ok(monkeypatch, bitstream_pat
         device.close()
 
 
-def test_xem7310_wrong_board_fails_before_configure(monkeypatch, bitstream_path):
+def test_xem7310_wrong_board_fails_before_configure(bitstream_path):
     FakeFrontPanel.product_name = "XEM7360"
     FakeFrontPanel.product_id = FakeFrontPanel.brdXEM7360K160T
-    monkeypatch.setattr(fpga_xem7310, "get_ok", lambda: FakeOk)
 
     with pytest.raises(TypeError, match="XEM7310A75/A200"):
         fpga.XEM7310(bitstream_path)

--- a/tests/test_pipe_endian.py
+++ b/tests/test_pipe_endian.py
@@ -29,6 +29,19 @@ def capture_warning_messages(call):
     return messages
 
 
+def capture_debug_messages(call):
+    messages = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]),
+        level="DEBUG",
+    )
+    try:
+        call()
+    finally:
+        logger.remove(sink_id)
+    return messages
+
+
 class CapturingPipeXem:
     def __init__(self, read_data: Optional[bytes] = None) -> None:
         self.pipe_in_calls = []
@@ -96,6 +109,15 @@ def test_pipe_methods_keep_endian_before_reorder_str(owner, method_name):
     assert parameters.index("endian") + 1 == parameters.index("reorder_str")
     assert parameters.index("reorder_str") + 1 == parameters.index("reverse")
     assert signature.parameters["reverse"].kind is inspect.Parameter.KEYWORD_ONLY
+    if method_name in {
+        "write_to_pipe_in",
+        "write_to_block_pipe_in",
+        "WriteToPipeIn",
+        "WriteToBlockPipeIn",
+    }:
+        assert parameters.index("reverse") + 1 == parameters.index("verbose")
+        assert signature.parameters["verbose"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert signature.parameters["verbose"].default is False
 
 
 def test_write_to_pipe_in_hex_defaults_to_little_endian_words():
@@ -179,6 +201,41 @@ def test_write_to_pipe_in_hex_reverse_reverses_word_order(kwargs, expected):
     )
 
     assert xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
+
+
+def test_write_to_pipe_in_verbose_logs_prepared_payload():
+    expected = "DDCCBBAA4433221188776655B2A10099"
+    xem = CapturingPipeXem()
+    ops = PipeOperations(xem)
+
+    messages = capture_debug_messages(
+        lambda: ops.write_to_pipe_in(
+            0x80,
+            "AABBCCDD11223344556677889900A1B2",
+            verbose=True,
+        )
+    )
+
+    assert xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
+    assert any("WriteToPipeIn" in message for message in messages)
+    assert any("0x80" in message for message in messages)
+    assert any(expected in message for message in messages)
+
+
+def test_write_to_pipe_in_verbose_false_does_not_log_payload():
+    expected = "DDCCBBAA4433221188776655B2A10099"
+    xem = CapturingPipeXem()
+    ops = PipeOperations(xem)
+
+    messages = capture_debug_messages(
+        lambda: ops.write_to_pipe_in(
+            0x80,
+            "AABBCCDD11223344556677889900A1B2",
+        )
+    )
+
+    assert xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
+    assert not any(expected in message for message in messages)
 
 
 @pytest.mark.parametrize(
@@ -624,6 +681,27 @@ def test_write_to_block_pipe_in_hex_reverse_reverses_word_order(kwargs, expected
     assert xem.block_pipe_in_calls == [(0x80, 16, bytes.fromhex(expected))]
 
 
+def test_write_to_block_pipe_in_verbose_logs_payload_and_block_size():
+    expected = "B2A100998877665544332211DDCCBBAA"
+    xem = CapturingBlockPipeXem()
+    ops = BlockPipeOperations(xem, bt_max_blocksize=16384)
+
+    messages = capture_debug_messages(
+        lambda: ops.write_to_block_pipe_in(
+            0x80,
+            "AABBCCDD11223344556677889900A1B2",
+            reverse=True,
+            verbose=True,
+        )
+    )
+
+    assert xem.block_pipe_in_calls == [(0x80, 16, bytes.fromhex(expected))]
+    assert any("WriteToBlockPipeIn" in message for message in messages)
+    assert any("0x80" in message for message in messages)
+    assert any("block_size=16" in message for message in messages)
+    assert any(expected in message for message in messages)
+
+
 def test_write_to_block_pipe_in_hex_reverse_uses_32_bit_words_for_usb2():
     xem = CapturingBlockPipeXem()
     ops = BlockPipeOperations(
@@ -746,6 +824,25 @@ def test_xem_pipe_wrapper_passes_reverse_to_write():
     ]
 
 
+def test_xem_pipe_wrapper_passes_verbose_to_write():
+    expected = "DDCCBBAA4433221188776655B2A10099"
+    pipe_xem = CapturingPipeXem()
+    fpga = EndpointXEM(pipe_ops=PipeOperations(pipe_xem))
+
+    messages = capture_debug_messages(
+        lambda: fpga.WriteToPipeIn(
+            0x80,
+            "AABBCCDD11223344556677889900A1B2",
+            verbose=True,
+        )
+    )
+
+    assert pipe_xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
+    assert any(
+        "WriteToPipeIn" in message and expected in message for message in messages
+    )
+
+
 def test_xem_pipe_wrapper_passes_reverse_to_read():
     pipe_xem = CapturingPipeXem(
         bytes.fromhex("DDCCBBAA4433221188776655B2A10099")
@@ -798,6 +895,30 @@ def test_xem_block_pipe_wrapper_passes_reverse_to_write():
     assert block_xem.block_pipe_in_calls == [
         (0x80, 16, bytes.fromhex("B2A100998877665544332211DDCCBBAA"))
     ]
+
+
+def test_xem_block_pipe_wrapper_passes_verbose_to_write():
+    expected = "DDCCBBAA4433221188776655B2A10099"
+    block_xem = CapturingBlockPipeXem()
+    fpga = EndpointXEM(
+        block_pipe_ops=BlockPipeOperations(block_xem, bt_max_blocksize=16384)
+    )
+
+    messages = capture_debug_messages(
+        lambda: fpga.WriteToBlockPipeIn(
+            0x80,
+            "AABBCCDD11223344556677889900A1B2",
+            verbose=True,
+        )
+    )
+
+    assert block_xem.block_pipe_in_calls == [(0x80, 16, bytes.fromhex(expected))]
+    assert any(
+        "WriteToBlockPipeIn" in message
+        and "block_size=16" in message
+        and expected in message
+        for message in messages
+    )
 
 
 def test_xem_block_pipe_wrapper_passes_reverse_to_read():

--- a/tests/test_pipe_endian.py
+++ b/tests/test_pipe_endian.py
@@ -221,9 +221,9 @@ def test_write_to_pipe_in_verbose_logs_payload_per_pipe_cycle():
     assert any("0x80" in message for message in messages)
     assert any("32-bit/cycle" in message for message in messages)
     assert not any(expected in message for message in messages)
-    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+    for cycle, payload in enumerate(["AABBCCDD", "11223344", "55667788", "9900A1B2"]):
         assert any(
-            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            f"cycle {cycle}" in message and f"FPGA 32-bit payload: {payload}" in message
             for message in messages
         )
 
@@ -707,9 +707,9 @@ def test_write_to_block_pipe_in_verbose_logs_usb3_payload_per_pipe_cycle_and_blo
     assert any("block_size=16" in message for message in messages)
     assert any("32-bit/cycle" in message for message in messages)
     assert not any(expected in message for message in messages)
-    for cycle, payload in enumerate(["B2A10099", "88776655", "44332211", "DDCCBBAA"]):
+    for cycle, payload in enumerate(["9900A1B2", "55667788", "11223344", "AABBCCDD"]):
         assert any(
-            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            f"cycle {cycle}" in message and f"FPGA 32-bit payload: {payload}" in message
             for message in messages
         )
 
@@ -733,9 +733,9 @@ def test_write_to_block_pipe_in_verbose_logs_usb2_payload_per_pipe_cycle():
     assert xem.block_pipe_in_calls == [(0x80, 2, bytes.fromhex(expected))]
     assert any("16-bit/cycle" in message for message in messages)
     assert not any(expected in message for message in messages)
-    for cycle, payload in enumerate(["BBAA", "DDCC"]):
+    for cycle, payload in enumerate(["AABB", "CCDD"]):
         assert any(
-            f"cycle {cycle}" in message and f"16-bit payload: {payload}" in message
+            f"cycle {cycle}" in message and f"FPGA 16-bit payload: {payload}" in message
             for message in messages
         )
 
@@ -879,9 +879,9 @@ def test_xem_pipe_wrapper_passes_verbose_to_write():
     assert not any(expected in message for message in messages)
     assert any("WriteToPipeIn" in message for message in messages)
     assert any("32-bit/cycle" in message for message in messages)
-    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+    for cycle, payload in enumerate(["AABBCCDD", "11223344", "55667788", "9900A1B2"]):
         assert any(
-            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            f"cycle {cycle}" in message and f"FPGA 32-bit payload: {payload}" in message
             for message in messages
         )
 
@@ -962,9 +962,9 @@ def test_xem_block_pipe_wrapper_passes_verbose_to_write():
         for message in messages
     )
     assert any("32-bit/cycle" in message for message in messages)
-    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+    for cycle, payload in enumerate(["AABBCCDD", "11223344", "55667788", "9900A1B2"]):
         assert any(
-            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            f"cycle {cycle}" in message and f"FPGA 32-bit payload: {payload}" in message
             for message in messages
         )
 

--- a/tests/test_pipe_endian.py
+++ b/tests/test_pipe_endian.py
@@ -203,7 +203,7 @@ def test_write_to_pipe_in_hex_reverse_reverses_word_order(kwargs, expected):
     assert xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
 
 
-def test_write_to_pipe_in_verbose_logs_prepared_payload():
+def test_write_to_pipe_in_verbose_logs_payload_per_pipe_cycle():
     expected = "DDCCBBAA4433221188776655B2A10099"
     xem = CapturingPipeXem()
     ops = PipeOperations(xem)
@@ -219,7 +219,13 @@ def test_write_to_pipe_in_verbose_logs_prepared_payload():
     assert xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
     assert any("WriteToPipeIn" in message for message in messages)
     assert any("0x80" in message for message in messages)
-    assert any(expected in message for message in messages)
+    assert any("32-bit/cycle" in message for message in messages)
+    assert not any(expected in message for message in messages)
+    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+        assert any(
+            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            for message in messages
+        )
 
 
 def test_write_to_pipe_in_verbose_false_does_not_log_payload():
@@ -681,7 +687,7 @@ def test_write_to_block_pipe_in_hex_reverse_reverses_word_order(kwargs, expected
     assert xem.block_pipe_in_calls == [(0x80, 16, bytes.fromhex(expected))]
 
 
-def test_write_to_block_pipe_in_verbose_logs_payload_and_block_size():
+def test_write_to_block_pipe_in_verbose_logs_usb3_payload_per_pipe_cycle_and_block_size():
     expected = "B2A100998877665544332211DDCCBBAA"
     xem = CapturingBlockPipeXem()
     ops = BlockPipeOperations(xem, bt_max_blocksize=16384)
@@ -699,7 +705,39 @@ def test_write_to_block_pipe_in_verbose_logs_payload_and_block_size():
     assert any("WriteToBlockPipeIn" in message for message in messages)
     assert any("0x80" in message for message in messages)
     assert any("block_size=16" in message for message in messages)
-    assert any(expected in message for message in messages)
+    assert any("32-bit/cycle" in message for message in messages)
+    assert not any(expected in message for message in messages)
+    for cycle, payload in enumerate(["B2A10099", "88776655", "44332211", "DDCCBBAA"]):
+        assert any(
+            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            for message in messages
+        )
+
+
+def test_write_to_block_pipe_in_verbose_logs_usb2_payload_per_pipe_cycle():
+    expected = "BBAADDCC"
+    xem = CapturingBlockPipeXem()
+    ops = BlockPipeOperations(
+        xem, bt_max_blocksize=64, usb_speed="FULL", device_interface="USB 2"
+    )
+
+    messages = capture_debug_messages(
+        lambda: ops.write_to_block_pipe_in(
+            0x80,
+            "AABBCCDD",
+            block_size=2,
+            verbose=True,
+        )
+    )
+
+    assert xem.block_pipe_in_calls == [(0x80, 2, bytes.fromhex(expected))]
+    assert any("16-bit/cycle" in message for message in messages)
+    assert not any(expected in message for message in messages)
+    for cycle, payload in enumerate(["BBAA", "DDCC"]):
+        assert any(
+            f"cycle {cycle}" in message and f"16-bit payload: {payload}" in message
+            for message in messages
+        )
 
 
 def test_write_to_block_pipe_in_hex_reverse_uses_32_bit_words_for_usb2():
@@ -838,9 +876,14 @@ def test_xem_pipe_wrapper_passes_verbose_to_write():
     )
 
     assert pipe_xem.pipe_in_calls == [(0x80, bytes.fromhex(expected))]
-    assert any(
-        "WriteToPipeIn" in message and expected in message for message in messages
-    )
+    assert not any(expected in message for message in messages)
+    assert any("WriteToPipeIn" in message for message in messages)
+    assert any("32-bit/cycle" in message for message in messages)
+    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+        assert any(
+            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            for message in messages
+        )
 
 
 def test_xem_pipe_wrapper_passes_reverse_to_read():
@@ -913,12 +956,17 @@ def test_xem_block_pipe_wrapper_passes_verbose_to_write():
     )
 
     assert block_xem.block_pipe_in_calls == [(0x80, 16, bytes.fromhex(expected))]
+    assert not any(expected in message for message in messages)
     assert any(
-        "WriteToBlockPipeIn" in message
-        and "block_size=16" in message
-        and expected in message
+        "WriteToBlockPipeIn" in message and "block_size=16" in message
         for message in messages
     )
+    assert any("32-bit/cycle" in message for message in messages)
+    for cycle, payload in enumerate(["DDCCBBAA", "44332211", "88776655", "B2A10099"]):
+        assert any(
+            f"cycle {cycle}" in message and f"32-bit payload: {payload}" in message
+            for message in messages
+        )
 
 
 def test_xem_block_pipe_wrapper_passes_reverse_to_read():

--- a/tests/test_platform_gate.py
+++ b/tests/test_platform_gate.py
@@ -80,12 +80,13 @@ def test_metadata_lookup_does_not_import_or_gate_package() -> None:
 def test_windows_simulated_public_api_and_cli_parser_import() -> None:
     result = _run_python(
         "import os\n"
+        "import numpy  # preload before Linux-host os.name Windows simulation\n"
         "from loguru import logger as _logger\n"
         "original = os.name\n"
         "os.name = 'nt'\n"
         "try:\n"
         "    import mms_ok\n"
-        "    expected = {'BIST', 'XEM7310', 'XEM7360', 'list_devices', "
+        "    expected = {'BIST', 'XEM', 'XEM7310', 'XEM7360', 'list_devices', "
         "'copy_frontpanel_files', 'setup_frontpanel', '__version__'}\n"
         "    missing = expected.difference(dir(mms_ok))\n"
         "    import mms_ok.cli as cli\n"
@@ -103,6 +104,7 @@ def test_windows_simulated_import_does_not_require_colorama() -> None:
     result = _run_python(
         "import os\n"
         "import sys\n"
+        "import numpy  # preload before Linux-host os.name Windows simulation\n"
         "from loguru import logger as _logger\n"
         "\n"
         "class BlockColorama:\n"
@@ -128,20 +130,55 @@ def test_windows_simulated_import_does_not_require_colorama() -> None:
 def test_windows_simulated_fpga_facade_import_identities() -> None:
     result = _run_python(
         "import os\n"
+        "import numpy  # preload before Linux-host os.name Windows simulation\n"
         "from loguru import logger as _logger\n"
         "original = os.name\n"
         "os.name = 'nt'\n"
         "try:\n"
         "    import mms_ok\n"
         "    from mms_ok import fpga\n"
-        "    from mms_ok.fpga_base import XEM\n"
+        "    from mms_ok.fpga_base import XEM as XEMBase\n"
+        "    from mms_ok.fpga_factory import XEM as autodetect_xem\n"
         "    from mms_ok.fpga_xem7310 import XEM7310\n"
         "    from mms_ok.fpga_xem7360 import XEM7360\n"
-        "    assert fpga.XEM is XEM\n"
+        "    assert fpga.XEM is XEMBase\n"
+        "    assert fpga.XEMBase is XEMBase\n"
+        "    assert fpga.autodetect_xem is autodetect_xem\n"
         "    assert fpga.XEM7310 is XEM7310\n"
         "    assert fpga.XEM7360 is XEM7360\n"
         "    assert mms_ok.XEM7310 is XEM7310\n"
         "    assert mms_ok.XEM7360 is XEM7360\n"
+        "    assert mms_ok.XEM is autodetect_xem\n"
+        "finally:\n"
+        "    os.name = original\n"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_windows_simulated_XEM_import_is_sdk_lazy() -> None:
+    result = _run_python(
+        "import os\n"
+        "import sys\n"
+        "import numpy  # preload before Linux-host os.name Windows simulation\n"
+        "from loguru import logger as _logger\n"
+        "\n"
+        "class BlockFrontPanel:\n"
+        "    def find_spec(self, fullname, path=None, target=None):\n"
+        "        if fullname in {'ok', '_ok'}:\n"
+        "            raise ModuleNotFoundError(fullname)\n"
+        "        return None\n"
+        "\n"
+        "sys.modules.pop('ok', None)\n"
+        "sys.modules.pop('_ok', None)\n"
+        "sys.meta_path.insert(0, BlockFrontPanel())\n"
+        "original = os.name\n"
+        "os.name = 'nt'\n"
+        "try:\n"
+        "    import mms_ok\n"
+        "    from mms_ok import fpga, XEM\n"
+        "    from mms_ok.fpga_base import XEM as XEMBase\n"
+        "    assert fpga.XEM is XEMBase\n"
         "finally:\n"
         "    os.name = original\n"
     )

--- a/tests/test_xem_autodetect.py
+++ b/tests/test_xem_autodetect.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import mms_ok
+from mms_ok import fpga
+from mms_ok import fpga_base
+from mms_ok import fpga_config
+from mms_ok import fpga_factory
+from mms_ok import fpga_generic
+from mms_ok import fpga_products
+from mms_ok import fpga_xem7360
+from mms_ok.devices import DeviceInfo
+from mms_ok.fpga_base import ProductIDMismatchError
+
+
+class FakeDeviceInfo:
+    def __init__(self) -> None:
+        self.productName = ""
+        self.serialNumber = ""
+        self.productID = 0
+        self.deviceInterface = 3
+        self.usbSpeed = 3
+        self.wireWidth = 32
+        self.triggerWidth = 32
+        self.pipeWidth = 32
+
+
+class FakeFrontPanel:
+    brdXEM7310A75 = 101
+    brdXEM7310A200 = 102
+    brdXEM7360K160T = 203
+
+    attached = []
+    instances = []
+    configure_error = 0
+    frontpanel_enabled = True
+
+    def __init__(self) -> None:
+        self.open = False
+        self.open_serial = None
+        self.selected = None
+        self.close_calls = 0
+        self.configure_calls = []
+        FakeFrontPanel.instances.append(self)
+
+    @staticmethod
+    def GetAPIVersionString() -> str:
+        return "test"
+
+    def OpenBySerial(self, serial: str) -> int:
+        self.open_serial = serial
+        target_serial = serial or (
+            FakeFrontPanel.attached[0]["serial"] if FakeFrontPanel.attached else None
+        )
+        for device in FakeFrontPanel.attached:
+            if device["serial"] == target_serial:
+                self.selected = device
+                self.open = True
+                return int(device.get("open_error", 0))
+        return -1
+
+    def GetDeviceInfo(self, device_info: FakeDeviceInfo) -> None:
+        if self.selected is None:
+            raise RuntimeError("no selected fake device")
+        device_info.productName = self.selected.get(
+            "open_model", self.selected["model"]
+        )
+        device_info.serialNumber = self.selected.get(
+            "open_serial_number", self.selected["serial"]
+        )
+        device_info.productID = self.selected.get(
+            "open_product_id", self.selected["product_id"]
+        )
+        device_info.deviceInterface = 3
+        device_info.usbSpeed = 3
+        device_info.wireWidth = 32
+        device_info.triggerWidth = 32
+        device_info.pipeWidth = 32
+
+    def ConfigureFPGA(self, bitstream_path: str) -> int:
+        self.configure_calls.append(bitstream_path)
+        return FakeFrontPanel.configure_error
+
+    def IsFrontPanelEnabled(self) -> bool:
+        return FakeFrontPanel.frontpanel_enabled
+
+    def IsOpen(self) -> bool:
+        return self.open
+
+    def Close(self) -> None:
+        self.close_calls += 1
+        self.open = False
+
+    @staticmethod
+    def GetDeviceSettings(handle, device_settings) -> None:
+        return None
+
+    @staticmethod
+    def GetErrorString(error_code: int) -> str:
+        return f"mock error {error_code}"
+
+
+class FakeDeviceSettings:
+    def GetInt(self, key: str) -> int:
+        values = {
+            "XEM7360_VADJ1_VOLTAGE": 120,
+            "XEM7360_VADJ2_VOLTAGE": 120,
+            "XEM7360_VADJ3_VOLTAGE": 120,
+            "XEM7360_VADJ_MODE": 0b0010_1010,
+        }
+        return values[key]
+
+
+class FakeOk:
+    OK_INTERFACE_USB3 = 3
+    okCFrontPanel = FakeFrontPanel
+    okTDeviceInfo = FakeDeviceInfo
+    okCDeviceSettings = FakeDeviceSettings
+
+
+@pytest.fixture(autouse=True)
+def fake_frontpanel(monkeypatch):
+    FakeFrontPanel.attached = []
+    FakeFrontPanel.instances = []
+    FakeFrontPanel.configure_error = 0
+    FakeFrontPanel.frontpanel_enabled = True
+
+    for module in (
+        fpga_base,
+        fpga_config,
+        fpga_products,
+        fpga_xem7360,
+    ):
+        monkeypatch.setattr(module, "get_ok", lambda: FakeOk)
+
+    monkeypatch.setattr(fpga_base, "print_fpga_overview", lambda **kwargs: None)
+    monkeypatch.setattr(fpga_factory, "list_devices", discovered_devices)
+
+
+@pytest.fixture
+def bitstream_path(tmp_path):
+    path = tmp_path / "design.bit"
+    path.write_bytes(b"fake bitstream")
+    return str(path)
+
+
+def add_device(serial: str, model: str, product_id: int, **overrides) -> None:
+    device = {
+        "serial": serial,
+        "model": model,
+        "device_id": overrides.pop("device_id", serial.lower()),
+        "product_id": product_id,
+    }
+    device.update(overrides)
+    FakeFrontPanel.attached.append(device)
+
+
+def discovered_devices():
+    return [
+        DeviceInfo(
+            serial=device["serial"],
+            model=device["model"],
+            device_id=device["device_id"],
+            product_id=device.get("discovery_product_id", device["product_id"]),
+        )
+        for device in FakeFrontPanel.attached
+    ]
+
+
+def test_xem_factory_is_top_level_lazy_public_and_facade_visible():
+    assert "XEM" in dir(mms_ok)
+    assert fpga.XEM is fpga_base.XEM
+    assert fpga.XEMBase is fpga_base.XEM
+    assert isinstance(fpga.XEM, type)
+    assert issubclass(fpga.XEM7310, fpga.XEM)
+    assert issubclass(fpga.XEM7360, fpga.XEM)
+    assert issubclass(fpga.UnverifiedXEM, fpga.XEM)
+    assert fpga.autodetect_xem is mms_ok.XEM
+    assert fpga.UnverifiedXEM is fpga_generic.UnverifiedXEM
+    assert fpga.ProductIDMismatchError is ProductIDMismatchError
+    assert "UnverifiedXEM" not in dir(mms_ok)
+
+
+@pytest.mark.parametrize(
+    ("product_id", "expected_model"),
+    [
+        (FakeFrontPanel.brdXEM7310A75, "XEM7310-A75"),
+        (FakeFrontPanel.brdXEM7310A200, "XEM7310-A200"),
+    ],
+)
+def test_xem_factory_returns_xem7310_for_verified_7310_products(
+    bitstream_path, product_id, expected_model
+):
+    add_device("SER7310", expected_model, product_id)
+
+    device = mms_ok.XEM(bitstream_path)
+
+    try:
+        assert isinstance(device, fpga.XEM)
+        assert isinstance(device, fpga.XEM7310)
+        assert device.config.product_id == product_id
+        assert FakeFrontPanel.instances[0].open_serial == "SER7310"
+        assert FakeFrontPanel.instances[0].configure_calls == [bitstream_path]
+    finally:
+        device.close()
+
+
+def test_xem_factory_returns_xem7360_for_k160t(bitstream_path):
+    add_device("SER7360", "XEM7360-K160T", FakeFrontPanel.brdXEM7360K160T)
+
+    device = mms_ok.XEM(bitstream_path)
+
+    try:
+        assert isinstance(device, fpga.XEM7360)
+        assert device.config.product_id == FakeFrontPanel.brdXEM7360K160T
+        assert device._vadj_voltage_dict == {
+            "vadj1": 1.2,
+            "vadj2": 1.2,
+            "vadj3": 1.2,
+        }
+    finally:
+        device.close()
+
+
+def test_xem_factory_returns_unverified_for_unknown_product(bitstream_path):
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+
+    with pytest.warns(RuntimeWarning, match="unverified|not hardware"):
+        device = mms_ok.XEM(bitstream_path)
+
+    try:
+        assert isinstance(device, fpga.UnverifiedXEM)
+        assert device.config.product_id == 999
+        assert FakeFrontPanel.instances[0].configure_calls == [bitstream_path]
+    finally:
+        device.close()
+
+
+def test_unverified_set_led_unsupported_and_does_not_mark_led_used(bitstream_path):
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+    with pytest.warns(RuntimeWarning):
+        device = mms_ok.XEM(bitstream_path)
+
+    try:
+        with pytest.raises(NotImplementedError, match="unsupported.*unverified"):
+            device.SetLED(1)
+        assert device._led_used is False
+    finally:
+        device.close()
+
+
+def test_unverified_warning_as_error_happens_before_open_or_configure(bitstream_path):
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with pytest.raises(RuntimeWarning, match="unverified"):
+            mms_ok.XEM(bitstream_path)
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+
+def test_unverified_common_apis_present(bitstream_path):
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+    with pytest.warns(RuntimeWarning):
+        device = mms_ok.XEM(bitstream_path)
+
+    try:
+        for attr in ("wire_ops", "trigger_ops", "pipe_ops", "block_pipe_ops"):
+            assert hasattr(device, attr)
+        for method in (
+            "SetWireInValue",
+            "ActivateTriggerIn",
+            "ReadFromPipeOut",
+            "WriteRegister",
+            "reset",
+            "close",
+        ):
+            assert hasattr(device, method)
+    finally:
+        device.close()
+
+
+def test_xem_factory_no_devices_raises_clear_error(bitstream_path):
+    with pytest.raises(fpga.FPGASelectionError, match="No Opal Kelly"):
+        mms_ok.XEM(bitstream_path)
+
+    assert FakeFrontPanel.instances == []
+
+
+def test_xem_factory_multiple_devices_without_serial_raises(bitstream_path):
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+    add_device("SER7360", "XEM7360-K160T", FakeFrontPanel.brdXEM7360K160T)
+
+    with pytest.raises(fpga.FPGASelectionError, match="Multiple.*serial"):
+        mms_ok.XEM(bitstream_path)
+
+    assert FakeFrontPanel.instances == []
+
+
+def test_xem_factory_with_serial_targets_matching_device(bitstream_path):
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+    add_device("SER7360", "XEM7360-K160T", FakeFrontPanel.brdXEM7360K160T)
+
+    device = mms_ok.XEM(bitstream_path, serial="SER7360")
+
+    try:
+        assert isinstance(device, fpga.XEM7360)
+        assert FakeFrontPanel.instances[0].open_serial == "SER7360"
+    finally:
+        device.close()
+
+
+def test_xem_factory_with_unknown_serial_raises_clear_error(bitstream_path):
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+
+    with pytest.raises(fpga.FPGASelectionError, match="SER404"):
+        mms_ok.XEM(bitstream_path, serial="SER404")
+
+    assert FakeFrontPanel.instances == []
+
+
+@pytest.mark.parametrize(
+    ("discovery_product_id", "open_product_id"),
+    [
+        (FakeFrontPanel.brdXEM7310A75, FakeFrontPanel.brdXEM7310A200),
+        (900, 901),
+    ],
+)
+def test_xem_factory_exact_product_change_fails_before_configure(
+    bitstream_path, discovery_product_id, open_product_id
+):
+    add_device(
+        "SERCHANGE",
+        "XEM-CHANGED",
+        open_product_id,
+        discovery_product_id=discovery_product_id,
+    )
+
+    with pytest.raises(ProductIDMismatchError, match="changed before configuration"):
+        mms_ok.XEM(bitstream_path)
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+
+def test_xem_factory_serial_change_fails_before_configure(bitstream_path):
+    add_device(
+        "SERCHANGE",
+        "XEM7310-A75",
+        FakeFrontPanel.brdXEM7310A75,
+        open_serial_number="SEROTHER",
+    )
+
+    with pytest.raises(ProductIDMismatchError, match="serial changed"):
+        mms_ok.XEM(bitstream_path)
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+
+def test_xem_factory_blank_opened_serial_fails_before_configure(bitstream_path):
+    add_device(
+        "SERCHANGE",
+        "XEM7310-A75",
+        FakeFrontPanel.brdXEM7310A75,
+        open_serial_number="",
+    )
+
+    with pytest.raises(ProductIDMismatchError, match="serial changed"):
+        mms_ok.XEM(bitstream_path)
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+
+def test_missing_required_product_id_constant_fails_clearly(monkeypatch, bitstream_path):
+    class MissingProductConstantOk:
+        class okCFrontPanel:
+            brdXEM7310A75 = FakeFrontPanel.brdXEM7310A75
+            brdXEM7310A200 = FakeFrontPanel.brdXEM7310A200
+
+    monkeypatch.setattr(fpga_products, "get_ok", lambda: MissingProductConstantOk)
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+
+    with pytest.raises(AttributeError, match="brdXEM7360K160T"):
+        mms_ok.XEM(bitstream_path)
+
+    assert FakeFrontPanel.instances == []
+
+
+def test_constructor_serial_keyword_only_and_records_serial(bitstream_path):
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+
+    with pytest.raises(TypeError):
+        fpga.XEM7310(bitstream_path, "SER7310")
+
+    device = fpga.XEM7310(bitstream_path, serial="SER7310")
+    try:
+        assert FakeFrontPanel.instances[0].open_serial == "SER7310"
+    finally:
+        device.close()
+
+
+def test_verified_constructors_with_serial_remain_strict(bitstream_path):
+    add_device("SERUNK", "XEM-UNKNOWN", 999)
+
+    with pytest.raises(TypeError, match="XEM7310A75/A200"):
+        fpga.XEM7310(bitstream_path, serial="SERUNK")
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+    FakeFrontPanel.instances = []
+    FakeFrontPanel.attached = []
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+
+    with pytest.raises(TypeError, match="XEM7360K160T"):
+        fpga.XEM7360(bitstream_path, serial="SER7310")
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []
+
+
+def test_unverified_direct_constructor_rejects_verified_boards_before_configure(
+    bitstream_path,
+):
+    add_device("SER7310", "XEM7310-A75", FakeFrontPanel.brdXEM7310A75)
+
+    with pytest.raises(TypeError, match="known verified"):
+        fpga.UnverifiedXEM(bitstream_path, serial="SER7310")
+
+    handle = FakeFrontPanel.instances[0]
+    assert handle.close_calls == 1
+    assert handle.configure_calls == []

--- a/tests/test_xem_autodetect.py
+++ b/tests/test_xem_autodetect.py
@@ -350,6 +350,23 @@ def test_xem_factory_exact_product_change_fails_before_configure(
     assert handle.configure_calls == []
 
 
+def test_xem_factory_accepts_bytes_opened_serial(bitstream_path):
+    add_device(
+        "SER7310",
+        "XEM7310-A75",
+        FakeFrontPanel.brdXEM7310A75,
+        open_serial_number=b"SER7310",
+    )
+
+    device = mms_ok.XEM(bitstream_path)
+
+    try:
+        assert isinstance(device, fpga.XEM7310)
+        assert FakeFrontPanel.instances[0].configure_calls == [bitstream_path]
+    finally:
+        device.close()
+
+
 def test_xem_factory_serial_change_fails_before_configure(bitstream_path):
     add_device(
         "SERCHANGE",


### PR DESCRIPTION
## Summary

- Add top-level `XEM(...)` autodetection that selects `XEM7310`, `XEM7360`, or a generic unverified FrontPanel device from discovered hardware, with `serial=...` targeting for multi-device setups.
- Add product-id helpers, `FPGASelectionError`, `ProductIDMismatchError`, and reopen-time serial/product-id guards so autodetected devices cannot drift before FPGA configuration.
- Add `UnverifiedXEM` for best-effort common FrontPanel API access on unverified Opal Kelly boards while keeping board-specific LED/BIST behavior limited to verified boards.
- Add `verbose=True` pipe-in and block-pipe-in payload logging that reports prepared FPGA-cycle hex chunks after endian/reverse handling.
- Update README guidance for autodetect usage, serial selection, generic unverified boards, and verbose pipe-in logging.
- Add focused regression coverage for XEM autodetect, serial/product-id guards, generic device behavior, pipe-in verbose logging, lifecycle handling, platform-gate exports, and bitstream constructor behavior.

## Impact

This makes normal board setup easier through `from mms_ok import XEM` while preserving strict `XEM7310`/`XEM7360` constructors for verified-board workflows. It also improves transfer debugging by exposing per-cycle pipe-in payload logs without changing transferred bytes or return values.

## Validation

- `python -m pytest` — 239 passed in 1.62s.
```
